### PR TITLE
feat / SS-150-CommonInputComponents - Input 공통 컴포넌트 구현

### DIFF
--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -1,3 +1,97 @@
-export const Input = () => {
-  return null;
-};
+"use client";
+
+import { forwardRef } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { inputHelperVariants, inputVariants } from "./input.variants";
+
+import type { IInputProps } from "./input.types";
+
+export const Input = forwardRef<HTMLInputElement, IInputProps>(
+  (
+    {
+      className,
+      fieldClassName,
+      helperText,
+      label,
+      leadingIcon,
+      trailingIcon,
+      variant = "default",
+      disabled = false,
+      id,
+      ...props
+    },
+    ref
+  ) => {
+    const helperId = helperText && id ? `${id}-helper` : undefined;
+
+    return (
+      <div className={cn("flex w-full flex-col gap-2", className)}>
+        {label ? (
+          <label htmlFor={id} className="type-label-sm text-on-surface-variant">
+            {label}
+          </label>
+        ) : null}
+
+        <div
+          className={cn(
+            "group flex w-full items-center overflow-hidden border bg-surface-variant transition-colors duration-200",
+            "focus-within:border-primary-container",
+            "focus-within:bg-surface",
+            "disabled:cursor-not-allowed",
+            inputVariants[variant],
+            disabled && "cursor-not-allowed opacity-50",
+            fieldClassName
+          )}
+        >
+          {leadingIcon ? (
+            <span className="ml-4 flex shrink-0 items-center text-[#8B908B]" aria-hidden="true">
+              {leadingIcon}
+            </span>
+          ) : null}
+
+          <input
+            ref={ref}
+            id={id}
+            disabled={disabled}
+            aria-invalid={variant === "error"}
+            aria-describedby={helperId}
+            className={cn(
+              "w-full bg-transparent text-body-sm text-on-background outline-none placeholder:text-[#B9B3AC]",
+              leadingIcon ? "pl-3" : "pl-5",
+              trailingIcon ? "pr-3" : "pr-5",
+              variant === "search" ? "py-4 font-semibold" : "py-[1.1rem]"
+            )}
+            {...props}
+          />
+
+          {trailingIcon ? (
+            <span className="mr-4 flex shrink-0 items-center text-[#8B908B]" aria-hidden="true">
+              {trailingIcon}
+            </span>
+          ) : null}
+        </div>
+
+        {helperText ? (
+          <p
+            id={helperId}
+            className={cn(
+              "flex items-center gap-1.5 type-label-md-regular",
+              inputHelperVariants[variant]
+            )}
+          >
+            {variant === "error" ? (
+              <span className="text-error" aria-hidden="true">
+                !
+              </span>
+            ) : null}
+            <span>{helperText}</span>
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+);
+
+Input.displayName = "Input";

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -29,7 +29,7 @@ export const Input = forwardRef<HTMLInputElement, IInputProps>(
     return (
       <div className={cn("flex w-full flex-col gap-2", className)}>
         {label ? (
-          <label htmlFor={id} className="type-label-sm text-on-surface-variant">
+          <label htmlFor={id} className="type-label-xs md:type-label-md text-on-surface-variant">
             {label}
           </label>
         ) : null}

--- a/src/components/ui/input/index.ts
+++ b/src/components/ui/input/index.ts
@@ -1,1 +1,3 @@
 export { Input } from "./Input";
+export type { IInputProps } from "./input.types";
+export { inputHelperVariants, inputVariants } from "./input.variants";

--- a/src/components/ui/input/input.stories.tsx
+++ b/src/components/ui/input/input.stories.tsx
@@ -1,0 +1,72 @@
+import { CircleAlert, Search } from "lucide-react";
+
+import { Input } from "./Input";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+const meta: Meta<typeof Input> = {
+  title: "UI/Input",
+  component: Input,
+  tags: ["autodocs"],
+  args: {
+    label: "이메일 주소 (EMAIL ADDRESS)",
+    placeholder: "example@stylesync.com",
+    variant: "default",
+  },
+  argTypes: {
+    leadingIcon: { control: false },
+    trailingIcon: { control: false },
+    fieldClassName: { control: false },
+  },
+  parameters: {
+    backgrounds: { default: "stylesync" },
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    className: "w-[320px]",
+  },
+};
+
+export const Error: Story = {
+  args: {
+    className: "w-[320px]",
+    label: "비밀번호 확인 (CONFIRM PASSWORD)",
+    placeholder: "********",
+    variant: "error",
+    helperText: "로그인·회원가입·비번·음악검색 (4개)",
+    trailingIcon: <CircleAlert size={18} />,
+  },
+};
+
+export const SearchBar: Story = {
+  args: {
+    className: "w-[640px]",
+    variant: "search",
+    placeholder: "Frank Ocean",
+    leadingIcon: <Search size={18} />,
+    label: undefined,
+  },
+};
+
+export const AuthExamples: Story = {
+  render: () => (
+    <div className="flex w-[320px] flex-col gap-6">
+      <Input label="이메일 주소 (EMAIL ADDRESS)" placeholder="curator@stylesync.com" />
+      <Input label="닉네임 (NICKNAME)" placeholder="@username" />
+      <Input label="비밀번호 (PASSWORD)" placeholder="********" type="password" />
+      <Input
+        label="비밀번호 확인 (CONFIRM PASSWORD)"
+        placeholder="********"
+        type="password"
+        variant="error"
+        helperText="비밀번호가 일치하지 않아요."
+      />
+    </div>
+  ),
+};

--- a/src/components/ui/input/input.types.ts
+++ b/src/components/ui/input/input.types.ts
@@ -1,0 +1,10 @@
+import type { InputHTMLAttributes, ReactNode } from "react";
+
+export interface IInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  variant?: "default" | "error" | "search";
+  label?: string;
+  helperText?: string;
+  leadingIcon?: ReactNode;
+  trailingIcon?: ReactNode;
+  fieldClassName?: string;
+}

--- a/src/components/ui/input/input.variants.ts
+++ b/src/components/ui/input/input.variants.ts
@@ -1,0 +1,12 @@
+export const inputVariants: Record<"default" | "error" | "search", string> = {
+  default: "min-h-14 rounded-2xl border-transparent",
+  error:
+    "min-h-14 rounded-2xl border-error bg-[#FFF6F6] focus-within:border-error focus-within:bg-[#FFF6F6]",
+  search: "min-h-14 rounded-full border-outline-variant bg-surface",
+};
+
+export const inputHelperVariants: Record<"default" | "error" | "search", string> = {
+  default: "text-on-surface-variant",
+  error: "text-error",
+  search: "text-on-surface-variant",
+};


### PR DESCRIPTION
### PR 제목
feat / SS-150-CommonInputComponents - Input 공통 컴포넌트 구현

### 반영 브랜치
SS-150-CommonInputComponents -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ]  기능 삭제
- [ ]  버그 수정
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용
- Input 공통 컴포넌트 구현
- default / error / search variant 설계
- label, helperText, leadingIcon, trailingIcon을 포함한 Props 설계
- 회원가입/로그인/비밀번호 확인/음악 검색 등 공통 입력 UI에 대응할 수 있도록 구성
- Storybook 스토리 작성
- 기본 상태, 에러 상태, 검색창 형태, 인증 폼 예시 확인 가능하도록 구성