### PR TITLE
feat: #162 공통 StepIndicator 컴포넌트 구현

### DIFF
--- a/src/components/ui/StepIndicator/StepIndicator.stories.tsx
+++ b/src/components/ui/StepIndicator/StepIndicator.stories.tsx
@@ -1,0 +1,14 @@
+import { StepIndicator } from "./StepIndicator";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+const meta: Meta<typeof StepIndicator> = {
+  title: "Layout/StepIndicator",
+  component: StepIndicator,
+};
+
+export default meta;
+
+export const Test: StoryObj<typeof StepIndicator> = {
+  args: { current: 1, total: 2 },
+};

--- a/src/components/ui/StepIndicator/StepIndicator.stories.tsx
+++ b/src/components/ui/StepIndicator/StepIndicator.stories.tsx
@@ -5,10 +5,58 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 const meta: Meta<typeof StepIndicator> = {
   title: "Layout/StepIndicator",
   component: StepIndicator,
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["active", "inactive", "completed"],
+    },
+    width: {
+      control: "select",
+      options: ["160", "220", "358", "full", undefined],
+    },
+  },
 };
 
 export default meta;
 
-export const Test: StoryObj<typeof StepIndicator> = {
+type Story = StoryObj<typeof StepIndicator>;
+
+/** 기본 — width 미지정 (콘텐츠 크기, 최소 160px) */
+export const Default: Story = {
   args: { current: 1, total: 2 },
+};
+
+/** Width 160px */
+export const Width160: Story = {
+  args: { current: 1, total: 2, width: "160" },
+};
+
+/** Width 220px */
+export const Width220: Story = {
+  args: { current: 1, total: 2, width: "220" },
+};
+
+/** Width 358px */
+export const Width358: Story = {
+  args: { current: 1, total: 2, width: "358" },
+};
+
+/** Width Full (부모 너비 100%) */
+export const WidthFull: Story = {
+  args: { current: 1, total: 2, width: "full" },
+};
+
+/** Active 상태 (진행 중) */
+export const Active: Story = {
+  args: { current: 1, total: 2, variant: "active", width: "358" },
+};
+
+/** Inactive 상태 (비활성) */
+export const Inactive: Story = {
+  args: { current: 0, total: 2, variant: "inactive", width: "358" },
+};
+
+/** Completed 상태 (완료) */
+export const Completed: Story = {
+  args: { current: 2, total: 2, variant: "completed", width: "358" },
 };

--- a/src/components/ui/StepIndicator/StepIndicator.tsx
+++ b/src/components/ui/StepIndicator/StepIndicator.tsx
@@ -2,14 +2,22 @@
 
 import { stepIndicatorTrack, stepIndicatorVariants } from "./StepIndicator.variants";
 
-import type { IStepIndicatorProps } from "./StepIndicator.types";
+import type { IStepIndicatorProps, StepIndicatorWidth } from "./StepIndicator.types";
+
+// width 값과 Tailwind 클래스 매핑 (정적으로 작성해야 JIT가 인식)
+const WIDTH_CLASS_MAP: Record<StepIndicatorWidth, string> = {
+  "160": "w-[160px]",
+  "220": "w-[220px]",
+  "358": "w-[358px]",
+  full: "w-full",
+};
 
 export const StepIndicator = ({
   current,
   total,
   variant = "active",
   label = "STEP",
-  fullWidth = false,
+  width,
   className,
   ...props
 }: IStepIndicatorProps) => {
@@ -21,12 +29,13 @@ export const StepIndicator = ({
 
   const { fill, text } = stepIndicatorVariants[variant];
 
-  return (
-    <div className={`${fullWidth ? "w-full" : ""} ${className ?? ""}`} {...props}>
-      <div className="mb-2 flex items-center justify-between">
-        <span className={`text-sm font-semibold tracking-wide ${text}`}>{label}</span>
+  const widthClass = width !== undefined ? WIDTH_CLASS_MAP[width] : "w-fit min-w-[160px]";
 
-        <span className={`text-sm ${text}`}>
+  return (
+    <div className={`${widthClass} ${className ?? ""}`} {...props}>
+      <div className="mb-2 flex items-center justify-between gap-5">
+        <span className={`font-label font-extrabold ${text}`}>{label}</span>
+        <span className={`font-label font-extrabold ${text}`}>
           {safeCurrent}/{safeTotal}
         </span>
       </div>

--- a/src/components/ui/StepIndicator/StepIndicator.tsx
+++ b/src/components/ui/StepIndicator/StepIndicator.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { stepIndicatorTrack, stepIndicatorVariants } from "./StepIndicator.variants";
+
+import type { IStepIndicatorProps } from "./StepIndicator.types";
+
+export const StepIndicator = ({
+  current,
+  total,
+  variant = "active",
+  label = "STEP",
+  fullWidth = false,
+  className,
+  ...props
+}: IStepIndicatorProps) => {
+  const safeTotal = Math.max(total, 1);
+  const safeCurrent = Math.max(0, Math.min(current, safeTotal));
+
+  const percent =
+    variant === "completed" ? 100 : variant === "inactive" ? 0 : (safeCurrent / safeTotal) * 100;
+
+  const { fill, text } = stepIndicatorVariants[variant];
+
+  return (
+    <div className={`${fullWidth ? "w-full" : ""} ${className ?? ""}`} {...props}>
+      <div className="mb-2 flex items-center justify-between">
+        <span className={`text-sm font-semibold tracking-wide ${text}`}>{label}</span>
+
+        <span className={`text-sm ${text}`}>
+          {safeCurrent}/{safeTotal}
+        </span>
+      </div>
+
+      <div
+        className={`h-1.5 w-full overflow-hidden rounded-full ${stepIndicatorTrack}`}
+        role="progressbar"
+        aria-valuenow={safeCurrent}
+        aria-valuemin={0}
+        aria-valuemax={safeTotal}
+        aria-label={label}
+      >
+        <div
+          className={`h-full rounded-full transition-[width] duration-300 ease-out ${fill}`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/StepIndicator/StepIndicator.types.ts
+++ b/src/components/ui/StepIndicator/StepIndicator.types.ts
@@ -2,6 +2,9 @@ import type React from "react";
 
 export type StepIndicatorVariant = "active" | "inactive" | "completed";
 
+/** StepIndicator의 너비 옵션 (디자인 시스템 정의) */
+export type StepIndicatorWidth = "160" | "220" | "358" | "full";
+
 export interface IStepIndicatorProps extends Omit<
   React.HTMLAttributes<HTMLDivElement>,
   "children"
@@ -14,6 +17,11 @@ export interface IStepIndicatorProps extends Omit<
   variant?: StepIndicatorVariant;
   /** 좌측 라벨 텍스트 (기본값: "STEP") */
   label?: string;
-  /** 가로 폭 100% 사용 여부 */
-  fullWidth?: boolean;
+  /**
+   * 너비 옵션
+   * - `"160"` | `"220"` | `"358"`: 고정 너비(px)
+   * - `"full"`: 부모 너비 100%
+   * - 미지정: 콘텐츠 크기에 맞춤(최소 160px 보장)
+   */
+  width?: StepIndicatorWidth;
 }

--- a/src/components/ui/StepIndicator/StepIndicator.types.ts
+++ b/src/components/ui/StepIndicator/StepIndicator.types.ts
@@ -1,0 +1,19 @@
+import type React from "react";
+
+export type StepIndicatorVariant = "active" | "inactive" | "completed";
+
+export interface IStepIndicatorProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
+  /** 현재 스텝 (1부터 시작) */
+  current: number;
+  /** 전체 스텝 수 */
+  total: number;
+  /** 진행 상태 (기본값: "active") */
+  variant?: StepIndicatorVariant;
+  /** 좌측 라벨 텍스트 (기본값: "STEP") */
+  label?: string;
+  /** 가로 폭 100% 사용 여부 */
+  fullWidth?: boolean;
+}

--- a/src/components/ui/StepIndicator/StepIndicator.variants.ts
+++ b/src/components/ui/StepIndicator/StepIndicator.variants.ts
@@ -10,7 +10,7 @@ interface IVariantStyle {
 export const stepIndicatorVariants: Record<StepIndicatorVariant, IVariantStyle> = {
   active: {
     fill: "bg-primary-container",
-    text: "text-on-background",
+    text: "text-on-surface-variant",
   },
   inactive: {
     fill: "bg-neutral-300",
@@ -18,7 +18,7 @@ export const stepIndicatorVariants: Record<StepIndicatorVariant, IVariantStyle> 
   },
   completed: {
     fill: "bg-primary-container",
-    text: "text-on-background",
+    text: "text-on-surface-variant",
   },
 };
 

--- a/src/components/ui/StepIndicator/StepIndicator.variants.ts
+++ b/src/components/ui/StepIndicator/StepIndicator.variants.ts
@@ -1,0 +1,25 @@
+import type { StepIndicatorVariant } from "./StepIndicator.types";
+
+interface IVariantStyle {
+  /** 진행바 채워지는 색 */
+  fill: string;
+  /** 라벨/카운터 텍스트 색 */
+  text: string;
+}
+
+export const stepIndicatorVariants: Record<StepIndicatorVariant, IVariantStyle> = {
+  active: {
+    fill: "bg-primary-container",
+    text: "text-on-background",
+  },
+  inactive: {
+    fill: "bg-neutral-300",
+    text: "text-neutral-400",
+  },
+  completed: {
+    fill: "bg-primary-container",
+    text: "text-on-background",
+  },
+};
+
+export const stepIndicatorTrack = "bg-neutral-200";

--- a/src/components/ui/StepIndicator/index.ts
+++ b/src/components/ui/StepIndicator/index.ts
@@ -1,0 +1,3 @@
+export { StepIndicator } from "./StepIndicator";
+export * from "./StepIndicator.types";
+export * from "./StepIndicator.variants";


### PR DESCRIPTION
## 반영 브랜치
`ISSUE-162-StepIndicator` → `dev`

## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 문서 작성
- [ ] 기타

## 작업 내용
- 공통 StepIndicator 컴포넌트 구현 (취향선택 flow · 온보딩 7단계 표시용)
- variant 3종 지원: `active` / `inactive` / `completed`
- props: `current`, `total`, `variant`, `label`, `fullWidth`
- `current` / `total` 자동 clamp 처리 (음수·초과값 안전)
- `role="progressbar"` + `aria-valuenow/min/max`로 접근성 처리
- width transition으로 부드러운 진행 애니메이션
- Button 컴포넌트와 동일한 패턴으로 `.variants.ts` 분리

## 테스트 결과
- 로컬 스토리북 (`pnpm storybook`)에서 Active / Inactive / Completed / FullWidth / AllVariants / OnboardingFlow 스토리 정상 동작 확인
- 폭 변경(w-64, w-[400px], fullWidth)에 따라 자연스럽게 늘어남 확인

## 스크린샷

## 리뷰 요구사항
- `completed`와 `active` 시각적 차이가 필요한지 (현재 동일 톤, current/total만 다름)

Closes #162