### PR TITLE
feat: #164 공통 PageIndicator 컴포넌트 구현

### DIFF
--- a/src/components/ui/PageIndicator/PageIndicator.stories.tsx
+++ b/src/components/ui/PageIndicator/PageIndicator.stories.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+
+import { PageIndicator } from "./PageIndicator";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+
+const meta: Meta<typeof PageIndicator> = {
+  title: "Layout/PageIndicator",
+  component: PageIndicator,
+  tags: ["autodocs"],
+  parameters: {
+    backgrounds: { default: "stylesync" },
+  },
+  argTypes: {
+    total: { control: { type: "number", min: 1 } },
+    current: { control: { type: "number", min: 0 } },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PageIndicator>;
+
+export const Default: Story = {
+  args: { total: 4, current: 0 },
+};
+
+export const Middle: Story = {
+  args: { total: 4, current: 1 },
+};
+
+export const Last: Story = {
+  args: { total: 4, current: 3 },
+};
+
+export const FivePages: Story = {
+  args: { total: 5, current: 2 },
+};
+
+export const ManyPages: Story = {
+  args: { total: 7, current: 3 },
+};
+
+export const AllSteps: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-8">
+      <PageIndicator total={4} current={0} />
+      <PageIndicator total={4} current={1} />
+      <PageIndicator total={4} current={2} />
+      <PageIndicator total={4} current={3} />
+    </div>
+  ),
+};
+
+export const Clickable: Story = {
+  render: () => {
+    const [page, setPage] = useState(0);
+
+    return (
+      <div className="flex flex-col items-start gap-4 p-8">
+        <PageIndicator total={4} current={page} onChange={setPage} />
+
+        <span className="text-sm text-neutral-500">현재 페이지: {page + 1} / 4</span>
+      </div>
+    );
+  },
+};

--- a/src/components/ui/PageIndicator/PageIndicator.tsx
+++ b/src/components/ui/PageIndicator/PageIndicator.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { IPageIndicatorProps } from "./PageIndicator.types";
+
+export const PageIndicator = ({
+  total,
+  current,
+  onChange,
+  className,
+  ...props
+}: IPageIndicatorProps) => {
+  const safeTotal = Math.max(total, 1);
+  const safeCurrent = Math.max(0, Math.min(current, safeTotal - 1));
+  const isInteractive = typeof onChange === "function";
+
+  return (
+    <div
+      role="group"
+      aria-label={`페이지 ${safeCurrent + 1} / ${safeTotal}`}
+      className={`flex items-center gap-2 ${className ?? ""}`}
+      {...props}
+    >
+      {Array.from({ length: safeTotal }).map((_, idx) => {
+        const isActive = idx === safeCurrent;
+        const dotClass = `h-3 rounded-full transition-all duration-300 ease-out ${
+          isActive ? "w-12 bg-primary-container" : "w-3 bg-neutral-200"
+        }`;
+
+        if (isInteractive) {
+          return (
+            <button
+              key={idx}
+              type="button"
+              onClick={(e) => {
+                e.currentTarget.blur();
+                onChange?.(idx);
+              }}
+              aria-label={`${idx + 1}번 페이지로 이동`}
+              aria-current={isActive ? "page" : undefined}
+              className={`${dotClass} cursor-pointer hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-container focus-visible:ring-offset-2`}
+            />
+          );
+        }
+
+        return <span key={idx} aria-hidden="true" className={dotClass} />;
+      })}
+    </div>
+  );
+};

--- a/src/components/ui/PageIndicator/PageIndicator.tsx
+++ b/src/components/ui/PageIndicator/PageIndicator.tsx
@@ -17,7 +17,7 @@ export const PageIndicator = ({
     <div
       role="group"
       aria-label={`페이지 ${safeCurrent + 1} / ${safeTotal}`}
-      className={`flex items-center gap-2 ${className ?? ""}`}
+      className={`flex items-center gap-4 ${className ?? ""}`}
       {...props}
     >
       {Array.from({ length: safeTotal }).map((_, idx) => {

--- a/src/components/ui/PageIndicator/PageIndicator.types.ts
+++ b/src/components/ui/PageIndicator/PageIndicator.types.ts
@@ -1,0 +1,10 @@
+import type React from "react";
+
+export interface IPageIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** 전체 페이지 수 */
+  total: number;
+  /** 현재 활성 페이지 (0부터 시작) */
+  current: number;
+  /** 점 클릭 시 호출되는 콜백. 제공하지 않으면 클릭 불가(단순 표시 용도) */
+  onChange?: (page: number) => void;
+}

--- a/src/components/ui/PageIndicator/index.ts
+++ b/src/components/ui/PageIndicator/index.ts
@@ -1,0 +1,2 @@
+export { PageIndicator } from "./PageIndicator";
+export * from "./PageIndicator.types";


### PR DESCRIPTION
## 반영 브랜치
`ISSUE-164-PageIndicator` → `dev`

## PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 스타일 수정
- [ ] 문서 작성
- [ ] 기타

## 작업 내용
- 공통 PageIndicator 컴포넌트 구현 (온보딩 페이지 등 위치 표시용)
- props: `total`, `current`, `onChange`
- 활성 점 캡슐형 확장(`w-12`) + 주황 fill로 강조
- `onChange` 제공 시 클릭으로 페이지 이동 가능 (`<button>` 렌더링)
- 클릭 후 자동 blur로 포커스 ring 남지 않게 처리
- 키보드 접근성: Tab + Enter/Space 지원, `focus-visible` 시 ring 표시
- `aria-current="page"`로 현재 페이지 명시
- `current` / `total` 자동 clamp 처리 (음수 · 초과값 안전)
- width transition으로 부드러운 활성 전환 애니메이션

## 테스트 결과
- 로컬 스토리북 (`pnpm storybook`)에서 모든 스토리 정상 동작 확인
  - Default / Middle / Last / FivePages / ManyPages / AllSteps / Clickable
- 클릭 이동 + 키보드 Tab 네비게이션 모두 확인

## 스크린샷


## 리뷰 요구사항
- `onChange` API 형태(인덱스 0부터 전달)가 사용 시점에 편한지

Closes #164