### PR TITLE
feat / SS-158-ButtonComponent - Button 컴포넌트 구현

### DIFF
--- a/src/app/testing/button/page.tsx
+++ b/src/app/testing/button/page.tsx
@@ -1,0 +1,116 @@
+import { ArrowRight, RefreshCw, Share2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <section className="flex flex-col gap-4">
+    <h2 className="font-headline font-black text-title-sm text-on-surface-variant uppercase tracking-widest border-b border-outline-variant pb-2">
+      {title}
+    </h2>
+    {children}
+  </section>
+);
+
+const Row = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex flex-wrap items-center gap-4">{children}</div>
+);
+
+export default function ButtonTestPage() {
+  return (
+    <main className="min-h-screen bg-background px-8 py-12 flex flex-col gap-12 max-w-3xl mx-auto">
+      <header>
+        <h1 className="font-headline font-black text-headline-sm text-on-background">
+          Button — 변형 테스트
+        </h1>
+        <p className="mt-1 text-body-sm text-on-surface-variant">
+          variant · size · icon · fullWidth · disabled
+        </p>
+      </header>
+
+      {/* ── Variants ──────────────────────────────────────────── */}
+      <Section title="Variants (md)">
+        <Row>
+          <Button variant="primary">primary</Button>
+          <Button variant="stroke">stroke</Button>
+          <Button variant="dark">dark</Button>
+          <Button variant="light">light</Button>
+          <Button variant="ghost">ghost</Button>
+        </Row>
+      </Section>
+
+      {/* ── Sizes ─────────────────────────────────────────────── */}
+      <Section title="Sizes (primary)">
+        <Row>
+          <Button size="sm">sm · 14px</Button>
+          <Button size="md">md · 18px</Button>
+          <Button size="lg">lg · 20px Bold</Button>
+        </Row>
+      </Section>
+
+      {/* ── Icons ─────────────────────────────────────────────── */}
+      <Section title="With Icon">
+        <Row>
+          <Button icon={<ArrowRight size={16} />}>지금 시작하기</Button>
+          <Button variant="stroke" icon={<ArrowRight size={16} />}>
+            둘러보기
+          </Button>
+          <Button variant="light" size="sm" icon={<Share2 size={18} />} iconPosition="left">
+            Instagram 공유
+          </Button>
+          <Button variant="dark" size="sm" icon={<Share2 size={18} />} iconPosition="left">
+            Twitter 공유
+          </Button>
+        </Row>
+      </Section>
+
+      {/* ── Full Width ────────────────────────────────────────── */}
+      <Section title="Full Width">
+        <Button fullWidth icon={<ArrowRight size={16} />}>
+          메일함으로 이동
+        </Button>
+        <Button variant="stroke" fullWidth icon={<RefreshCw size={16} />}>
+          메일 다시 받기
+        </Button>
+        <Button variant="ghost" fullWidth>
+          나중에 할게요 →
+        </Button>
+      </Section>
+
+      {/* ── Hero CTA ──────────────────────────────────────────── */}
+      <Section title="Hero CTA (lg)">
+        <Button size="lg" icon={<ArrowRight size={24} />}>
+          첫 취향 분석 시작하기
+        </Button>
+      </Section>
+
+      {/* ── Disabled ──────────────────────────────────────────── */}
+      <Section title="Disabled">
+        <Row>
+          <Button disabled>primary</Button>
+          <Button variant="stroke" disabled>
+            stroke
+          </Button>
+          <Button variant="dark" disabled>
+            dark
+          </Button>
+        </Row>
+      </Section>
+
+      {/* ── Dark background ───────────────────────────────────── */}
+      <Section title="On Dark Background">
+        <div className="bg-inverse-surface rounded-2xl p-6 flex flex-wrap gap-4">
+          <Button variant="primary" icon={<ArrowRight size={16} />}>
+            지금 시작하기
+          </Button>
+          <Button variant="stroke">둘러보기</Button>
+          <Button variant="light" size="sm">
+            light on dark
+          </Button>
+          <Button variant="ghost" size="sm">
+            나중에 할게요 →
+          </Button>
+        </div>
+      </Section>
+    </main>
+  );
+}

--- a/src/components/ui/button/Button.tsx
+++ b/src/components/ui/button/Button.tsx
@@ -1,3 +1,34 @@
-export const Button = () => {
-  return null;
+"use client";
+
+import { cn } from "@/lib/utils";
+
+import { IButton } from "./Button.types";
+import { buttonVariants } from "./button.variants";
+
+export const Button = ({
+  variant,
+  size,
+  fullWidth,
+  icon,
+  iconPosition = "right",
+  className,
+  children,
+  type = "button",
+  ...props
+}: IButton) => {
+  return (
+    <button
+      type={type}
+      className={cn(buttonVariants({ variant, size, fullWidth }), className)}
+      {...props}
+    >
+      {icon && iconPosition === "left" && (
+        <span className="shrink-0 flex items-center">{icon}</span>
+      )}
+      {children}
+      {icon && iconPosition === "right" && (
+        <span className="shrink-0 flex items-center">{icon}</span>
+      )}
+    </button>
+  );
 };

--- a/src/components/ui/button/Button.types.ts
+++ b/src/components/ui/button/Button.types.ts
@@ -1,0 +1,11 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+import { buttonVariants } from "./button.variants";
+
+import type { VariantProps } from "class-variance-authority";
+
+export interface IButton
+  extends ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  icon?: ReactNode;
+  iconPosition?: "left" | "right";
+}

--- a/src/components/ui/button/button.stories.tsx
+++ b/src/components/ui/button/button.stories.tsx
@@ -1,0 +1,153 @@
+import { ArrowRight, RefreshCw, Share2 } from "lucide-react";
+
+import { Button } from "./Button";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+const meta: Meta<typeof Button> = {
+  title: "UI/Button",
+  component: Button,
+  tags: ["autodocs"],
+  parameters: {
+    backgrounds: { default: "stylesync" },
+    docs: {
+      description: {
+        component: `
+공통 버튼 컴포넌트입니다. 전 페이지에서 사용됩니다.
+
+## Variants
+| Variant | 용도 |
+|---|---|
+| \`primary\` | 주요 CTA — 오렌지 배경 |
+| \`stroke\` | 보조 액션 — 아웃라인 |
+| \`dark\` | 다크 컨텍스트 (예: Google 로그인) |
+| \`light\` | 밝은 카드 위 — 흰 배경 + 그림자 |
+| \`ghost\` | 텍스트 전용 인라인 액션 |
+
+## Sizes
+| Size | Height | Font | 용도 |
+|---|---|---|---|
+| \`sm\` | 48px | 14px Medium | 소형 인라인, 소셜 공유 |
+| \`md\` | auto (py-5) | 18px Regular | 기본 CTA |
+| \`lg\` | auto (py-10) | 20px Bold | 히어로 CTA |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "stroke", "dark", "light", "ghost"],
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+    fullWidth: { control: "boolean" },
+    disabled: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: { variant: "primary", size: "md", children: "지금 시작하기" },
+};
+
+export const PrimaryWithIcon: Story = {
+  name: "Primary · 아이콘",
+  args: {
+    variant: "primary",
+    size: "md",
+    children: "지금 시작하기",
+    icon: <ArrowRight size={16} />,
+  },
+};
+
+export const Stroke: Story = {
+  args: { variant: "stroke", size: "md", children: "둘러보기" },
+};
+
+export const Dark: Story = {
+  args: { variant: "dark", size: "sm", children: "Google로 시작하기" },
+};
+
+export const Light: Story = {
+  args: {
+    variant: "light",
+    size: "sm",
+    children: "Instagram 공유",
+    icon: <Share2 size={20} />,
+    iconPosition: "left",
+  },
+};
+
+export const Ghost: Story = {
+  args: { variant: "ghost", size: "sm", children: "나중에 할게요 →" },
+};
+
+export const HeroCTA: Story = {
+  name: "Hero CTA · lg",
+  args: {
+    variant: "primary",
+    size: "lg",
+    children: "첫 취향 분석 시작하기",
+    icon: <ArrowRight size={24} />,
+  },
+};
+
+export const FullWidth: Story = {
+  args: {
+    variant: "primary",
+    size: "md",
+    fullWidth: true,
+    children: "메일함으로 이동",
+    icon: <ArrowRight size={16} />,
+  },
+};
+
+export const StrokeFullWidth: Story = {
+  name: "Stroke · Full Width",
+  args: {
+    variant: "stroke",
+    size: "md",
+    fullWidth: true,
+    children: "메일 다시 받기",
+    icon: <RefreshCw size={16} />,
+    iconPosition: "right",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: "primary",
+    size: "md",
+    children: "선택해주세요",
+    disabled: true,
+  },
+};
+
+export const AllVariants: Story = {
+  name: "전체 Variants",
+  render: () => (
+    <div className="flex flex-col gap-4 p-8 max-w-sm">
+      <Button variant="primary" icon={<ArrowRight size={16} />}>
+        지금 시작하기
+      </Button>
+      <Button variant="stroke">둘러보기</Button>
+      <Button variant="dark" size="sm">
+        Google로 시작하기
+      </Button>
+      <Button variant="light" size="sm" icon={<Share2 size={20} />} iconPosition="left">
+        Instagram 공유
+      </Button>
+      <Button variant="ghost" size="sm">
+        나중에 할게요 →
+      </Button>
+      <Button variant="primary" disabled>
+        선택해주세요
+      </Button>
+    </div>
+  ),
+};

--- a/src/components/ui/button/button.variants.ts
+++ b/src/components/ui/button/button.variants.ts
@@ -1,0 +1,37 @@
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  [
+    "inline-flex items-center justify-center rounded-full",
+    "font-korean whitespace-nowrap cursor-pointer select-none",
+    "transition-all duration-200 active:scale-[0.98]",
+    "disabled:opacity-40 disabled:pointer-events-none",
+  ].join(" "),
+  {
+    variants: {
+      variant: {
+        primary: "bg-primary-container text-on-primary hover:opacity-90",
+        stroke:
+          "border border-primary-container text-primary-container hover:bg-primary-container/5",
+        dark: "bg-on-background text-surface hover:opacity-90",
+        light:
+          "bg-surface text-on-background shadow-[0px_4px_8px_rgba(12,12,13,0.1)] hover:opacity-90",
+        ghost: "text-on-surface-variant hover:text-on-background",
+      },
+      size: {
+        sm: "h-12 px-8 gap-2 font-medium",
+        md: "py-5 px-10 gap-3 font-normal",
+        lg: "py-10 px-32 gap-4 font-bold",
+      },
+      fullWidth: {
+        true: "w-full",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "md",
+      fullWidth: false,
+    },
+  }
+);

--- a/src/components/ui/button/button.variants.ts
+++ b/src/components/ui/button/button.variants.ts
@@ -19,9 +19,9 @@ export const buttonVariants = cva(
         ghost: "text-on-surface-variant hover:text-on-background",
       },
       size: {
-        sm: "h-12 px-8 gap-2 font-medium",
-        md: "py-5 px-10 gap-3 font-normal",
-        lg: "py-10 px-32 gap-4 font-bold",
+        sm: "h-12 px-8 gap-2 font-medium text-label-lg",
+        md: "py-5 px-10 gap-3 font-normal text-body-md md:text-body-lg",
+        lg: "py-5 px-10 gap-3 font-normal text-body-md md:py-10 md:px-32 md:gap-4 md:font-bold md:text-title-lg",
       },
       fullWidth: {
         true: "w-full",

--- a/src/components/ui/button/index.ts
+++ b/src/components/ui/button/index.ts
@@ -1,1 +1,3 @@
 export { Button } from "./Button";
+export type { IButton } from "./Button.types";
+export { buttonVariants } from "./button.variants";


### PR DESCRIPTION
## PR 제목

feat / SS-158-ButtonComponent - Button 컴포넌트 구현

## PR 본문

### 반영 브랜치

SS-158-ButtonComponent -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

- `Button.types.ts`: IButton 인터페이스 타입 정의 (variant, size, fullWidth, icon, iconPosition props)
- `button.variants.ts`: CVA 기반 variant(primary/stroke/dark/light/ghost) · size(sm/md/lg) · fullWidth 스타일 정의
- `Button.tsx`: shell에서 실제 구현체로 교체, 아이콘 좌우 배치 지원
- `index.ts`: IButton, buttonVariants re-export 추가
- `button.stories.tsx`: 모든 variant/size 조합 Storybook stories 추가
- `src/app/testing/button/page.tsx`: 시각 검증용 테스트 페이지 추가

### 테스트 결과 (선택)

Storybook 및 `/testing/button` 테스트 페이지에서 모든 variant/size 조합 시각 검증

### 스크린샷 (선택)

### 리뷰 요구사항(선택)

- size variant에서 text 크기 클래스를 분리했습니다. 타이포그래피 토큰 적용 방식이 맞는지 확인 부탁드립니다.