### PR TITLE
fix / ISSUE-178-FixCnTailwindMerge - cn() tailwind-merge 커스텀 fontSize 인식 처리

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,41 @@
 import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+// ── tailwind-merge 확장 설정 ──────────────────────────────────────────────────
+// 기본 twMerge는 tailwind.config.ts에 정의된 커스텀 fontSize 토큰
+// (text-label-lg, text-body-lg 등)을 인식하지 못해, text-* 색상 클래스와
+// 같은 그룹으로 처리되어 색상이 지워지는 문제가 발생한다.
+// fontSize 그룹에 프로젝트 토큰을 명시해서 충돌을 방지한다.
+const customTwMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            "display-lg",
+            "display-md",
+            "display-sm",
+            "headline-lg",
+            "headline-md",
+            "headline-sm",
+            "title-lg",
+            "title-md",
+            "title-sm",
+            "body-lg",
+            "body-md",
+            "body-sm",
+            "label-lg",
+            "label-md",
+            "label-sm",
+            "label-md-regular",
+            "label-xs",
+          ],
+        },
+      ],
+    },
+  },
+});
 
 export const cn = (...inputs: ClassValue[]) => {
-  return twMerge(clsx(inputs));
+  return customTwMerge(clsx(inputs));
 };


### PR DESCRIPTION
## 반영 브랜치

ISSUE-178-FixCnTailwindMerge → dev

## 관련 이슈

#178

## PR 타입

- [x] 버그 수정

## 작업 내용

- `cn()`이 사용하는 `twMerge`가 `tailwind.config.ts`의 커스텀 fontSize 토큰(`text-label-lg`, `text-body-lg` 등)을 인식하지 못해 `text-*` 색상 클래스와 충돌로 처리되어 색상이 사라지는 버그 수정
- `extendTailwindMerge`로 프로젝트 fontSize 토큰을 `font-size` 그룹에 등록

## 테스트 결과

수정 전 (Button primary variant):
```html
<button class="... bg-primary-container ... text-label-lg">
  공유 카드 만들기
</button>
```
→ `text-on-primary` 누락으로 텍스트가 body 기본 색상(검정)으로 표시됨

수정 후:
```html
<button class="... bg-primary-container text-on-primary ... text-label-lg">
  공유 카드 만들기
</button>
```
→ `text-on-primary`(흰색) 정상 적용

## 리뷰 요구사항

- `extendTailwindMerge`에 등록한 fontSize 토큰 리스트가 `tailwind.config.ts`와 일치하는지 확인 부탁드려요
- 앞으로 fontSize 토큰을 추가할 때 이 파일에도 함께 추가해야 합니다