### PR TITLE
feat / SS-55-InferenceTypes - TypeScript 타입 정의

### DIFF
--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -1,8 +1,11 @@
 export type {
   InferenceRequest,
   InferenceResponse,
+  InferenceResult,
   MusicRecommendation,
   MovieRecommendation,
   FashionRecommendation,
+  StyleLabel,
   Domain,
+  IInferenceService,
 } from "./inference.types";

--- a/src/lib/inference/inference.types.ts
+++ b/src/lib/inference/inference.types.ts
@@ -38,3 +38,12 @@ export type InferenceResponse = {
 };
 
 export type { Domain };
+
+// ─── Utility types ────────────────────────────────────────────────────────────
+
+export type StyleLabel = InferenceResponse["styleLabel"];
+
+export type InferenceResult = InferenceResponse & {
+  id: string;
+  createdAt: string;
+};

--- a/src/lib/inference/inference.types.ts
+++ b/src/lib/inference/inference.types.ts
@@ -47,3 +47,9 @@ export type InferenceResult = InferenceResponse & {
   id: string;
   createdAt: string;
 };
+
+// ─── Service interface ────────────────────────────────────────────────────────
+
+export interface IInferenceService {
+  call(request: InferenceRequest): Promise<InferenceResponse>;
+}


### PR DESCRIPTION
## PR 제목

feat / SS-55-InferenceTypes - TypeScript 타입 정의

## PR 본문

### 반영 브랜치

SS-55-InferenceTypes -> SS-52-InferenceSchema

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

closes #55

`src/lib/inference/inference.types.ts` 및 `src/lib/inference/index.ts` 에 타입 정의를 추가합니다.

- `StyleLabel` — `InferenceResponse["styleLabel"]` 에서 인덱스 접근으로 도출한 유틸리티 타입
- `InferenceResult` — 저장된 추론 결과를 표현하는 타입 (`InferenceResponse & { id, createdAt }`)
- `IInferenceService` — 추론 서비스의 서비스 인터페이스 (`call(request): Promise<InferenceResponse>`)
- `index.ts` re-export에 위 3종 추가

### 테스트 결과 (선택)

`pnpm tsc --noEmit --skipLibCheck` 통과

### 리뷰 요구사항(선택)

- `src/types/result.ts`의 `StyleResult`와의 정합 (`movie` vs `movies` 필드명)은 #175 이슈에서 팀 논의 후 별도 처리 예정