### PR TITLE
feat / SS-56-InferenceZod - Zod 검증 스키마 작성

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -4417,6 +4420,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
@@ -8983,6 +8989,8 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.12(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     optionalDependencies:

--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -14,4 +14,5 @@ export {
   InferenceRequestSchema,
   InferenceResponseSchema,
   safeParseRequest,
+  safeParseResponse,
 } from "./inference.schema";

--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -13,6 +13,7 @@ export type {
 export {
   InferenceRequestSchema,
   InferenceResponseSchema,
+  InferenceResultSchema,
   safeParseRequest,
   safeParseResponse,
 } from "./inference.schema";

--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -9,3 +9,9 @@ export type {
   Domain,
   IInferenceService,
 } from "./inference.types";
+
+export {
+  InferenceRequestSchema,
+  InferenceResponseSchema,
+  safeParseRequest,
+} from "./inference.schema";

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -92,6 +92,11 @@ export const InferenceResponseSchema = z.object({
     .max(10, { message: "패션 추천은 최대 10개까지 가능합니다" }),
 });
 
+export const InferenceResultSchema = InferenceResponseSchema.extend({
+  id: z.string(),
+  createdAt: z.string(),
+});
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 export function safeParseRequest(input: unknown) {

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -80,12 +80,15 @@ export const InferenceResponseSchema = z.object({
   description: z.string().min(1, { message: "설명은 비어있을 수 없습니다" }),
   music: z
     .array(MusicRecommendationSchema)
+    .min(1, { message: "음악 추천은 최소 1개 이상이어야 합니다" })
     .max(10, { message: "음악 추천은 최대 10개까지 가능합니다" }),
   movie: z
     .array(MovieRecommendationSchema)
+    .min(1, { message: "영화 추천은 최소 1개 이상이어야 합니다" })
     .max(10, { message: "영화 추천은 최대 10개까지 가능합니다" }),
   fashion: z
     .array(FashionRecommendationSchema)
+    .min(1, { message: "패션 추천은 최소 1개 이상이어야 합니다" })
     .max(10, { message: "패션 추천은 최대 10개까지 가능합니다" }),
 });
 

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -88,3 +88,9 @@ export const InferenceResponseSchema = z.object({
     .array(FashionRecommendationSchema)
     .max(10, { message: "패션 추천은 최대 10개까지 가능합니다" }),
 });
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function safeParseRequest(input: unknown) {
+  return InferenceRequestSchema.safeParse(input);
+}

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -75,11 +75,8 @@ const MovieRecommendationSchema = z.object({
 });
 
 const FashionRecommendationSchema = z.object({
-  id: z.string(),
-  name: z.string(),
+  keyword: z.string().min(1, { message: "패션 키워드는 비어있을 수 없습니다" }),
   image: z.string(),
-  price: z.number().min(0, { message: "가격은 0 이상이어야 합니다" }),
-  link: z.string().url(),
 });
 
 // ─── Response ─────────────────────────────────────────────────────────────────

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -44,3 +44,47 @@ export const InferenceRequestSchema = z.discriminatedUnion("domain", [
     moods: MoodsSchema,
   }),
 ]);
+
+// ─── Recommendations ──────────────────────────────────────────────────────────
+
+const MusicRecommendationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  artist: z.string(),
+  image: z.string(),
+  previewUrl: z.string().nullable(),
+});
+
+const MovieRecommendationSchema = z.object({
+  id: z.number().int(),
+  title: z.string(),
+  posterPath: z.string(),
+  genres: z.array(z.string()),
+});
+
+const FashionRecommendationSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  image: z.string(),
+  price: z.number().nonnegative({ message: "가격은 0 이상이어야 합니다" }),
+  link: z.string().url({ message: "유효한 URL 형식이어야 합니다" }),
+});
+
+// ─── Response ─────────────────────────────────────────────────────────────────
+
+export const InferenceResponseSchema = z.object({
+  styleLabel: z
+    .string()
+    .min(1, { message: "스타일 레이블은 비어있을 수 없습니다" })
+    .max(40, { message: "스타일 레이블은 최대 40자까지 입력 가능합니다" }),
+  description: z.string().min(1, { message: "설명은 비어있을 수 없습니다" }),
+  music: z
+    .array(MusicRecommendationSchema)
+    .max(10, { message: "음악 추천은 최대 10개까지 가능합니다" }),
+  movie: z
+    .array(MovieRecommendationSchema)
+    .max(10, { message: "영화 추천은 최대 10개까지 가능합니다" }),
+  fashion: z
+    .array(FashionRecommendationSchema)
+    .max(10, { message: "패션 추천은 최대 10개까지 가능합니다" }),
+});

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -66,7 +66,7 @@ const FashionRecommendationSchema = z.object({
   id: z.string(),
   name: z.string(),
   image: z.string(),
-  price: z.number().nonnegative({ message: "가격은 0 이상이어야 합니다" }),
+  price: z.number().min(0, { message: "가격은 0 이상이어야 합니다" }),
   link: z.string().url(),
 });
 

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -97,3 +97,7 @@ export const InferenceResponseSchema = z.object({
 export function safeParseRequest(input: unknown) {
   return InferenceRequestSchema.safeParse(input);
 }
+
+export function safeParseResponse(input: unknown) {
+  return InferenceResponseSchema.safeParse(input);
+}

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+// ─── Mood ─────────────────────────────────────────────────────────────────────
+
+const MoodSchema = z.string().min(1, { message: "감성 태그는 비어있을 수 없습니다" });
+
+const MoodsSchema = z
+  .array(MoodSchema)
+  .min(1, { message: "감성 태그는 최소 1개 이상 선택해주세요" })
+  .max(5, { message: "감성 태그는 최대 5개까지 선택 가능합니다" });
+
+// ─── Selections ───────────────────────────────────────────────────────────────
+
+const MusicSelectionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  image: z.string(),
+  genre: z.array(z.string()),
+  previewUrl: z.string().nullable(),
+});
+
+const MovieSelectionSchema = z.object({
+  id: z.number().int(),
+  title: z.string(),
+  posterPath: z.string(),
+  backdropPath: z.string(),
+  genres: z.array(z.string()),
+  releaseYear: z.number().int().min(1888, { message: "출시 연도가 유효하지 않습니다" }),
+});
+
+const FashionSelectionSchema = z.object({
+  styles: z.array(z.string()).min(1, { message: "스타일은 최소 1개 이상 선택해주세요" }),
+  moods: z.array(z.string()).min(1, { message: "패션 무드는 최소 1개 이상 선택해주세요" }),
+});
+
+// ─── Request ──────────────────────────────────────────────────────────────────
+
+export const InferenceRequestSchema = z.discriminatedUnion("domain", [
+  z.object({ domain: z.literal("music"), selections: MusicSelectionSchema, moods: MoodsSchema }),
+  z.object({ domain: z.literal("movie"), selections: MovieSelectionSchema, moods: MoodsSchema }),
+  z.object({
+    domain: z.literal("fashion"),
+    selections: FashionSelectionSchema,
+    moods: MoodsSchema,
+  }),
+]);

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -22,8 +22,8 @@ const MusicSelectionSchema = z.object({
 const MovieSelectionSchema = z.object({
   id: z.number().int(),
   title: z.string(),
-  posterPath: z.string(),
-  backdropPath: z.string(),
+  posterPath: z.string().regex(/^\//, { message: "TMDB 경로는 /로 시작해야 합니다" }),
+  backdropPath: z.string().regex(/^\//, { message: "TMDB 경로는 /로 시작해야 합니다" }),
   genres: z.array(z.string()),
   releaseYear: z.number().int().min(1888, { message: "출시 연도가 유효하지 않습니다" }),
 });

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -35,12 +35,24 @@ const FashionSelectionSchema = z.object({
 
 // ─── Request ──────────────────────────────────────────────────────────────────
 
+const SelectionsSchema = {
+  music: z
+    .array(MusicSelectionSchema)
+    .min(3, { message: "취향 카드는 최소 3개 이상 선택해주세요" }),
+  movie: z
+    .array(MovieSelectionSchema)
+    .min(3, { message: "취향 카드는 최소 3개 이상 선택해주세요" }),
+  fashion: z
+    .array(FashionSelectionSchema)
+    .min(1, { message: "취향 카드는 최소 1개 이상 선택해주세요" }),
+};
+
 export const InferenceRequestSchema = z.discriminatedUnion("domain", [
-  z.object({ domain: z.literal("music"), selections: MusicSelectionSchema, moods: MoodsSchema }),
-  z.object({ domain: z.literal("movie"), selections: MovieSelectionSchema, moods: MoodsSchema }),
+  z.object({ domain: z.literal("music"), selections: SelectionsSchema.music, moods: MoodsSchema }),
+  z.object({ domain: z.literal("movie"), selections: SelectionsSchema.movie, moods: MoodsSchema }),
   z.object({
     domain: z.literal("fashion"),
-    selections: FashionSelectionSchema,
+    selections: SelectionsSchema.fashion,
     moods: MoodsSchema,
   }),
 ]);

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -67,7 +67,7 @@ const FashionRecommendationSchema = z.object({
   name: z.string(),
   image: z.string(),
   price: z.number().nonnegative({ message: "가격은 0 이상이어야 합니다" }),
-  link: z.string().url({ message: "유효한 URL 형식이어야 합니다" }),
+  link: z.string().url(),
 });
 
 // ─── Response ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## PR 제목

feat / SS-56-InferenceZod - Zod 검증 스키마 작성

## PR 본문

### 반영 브랜치

SS-56-InferenceZod -> SS-55-InferenceTypes

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

closes #56

`src/lib/inference/inference.schema.ts` 신설 및 `zod` 의존성 추가.

**InferenceRequestSchema**
- `z.discriminatedUnion("domain", [...])` — domain 값과 selections 타입을 컴파일 타임 + 런타임 양쪽에서 강제
- `moods`: min(1) / max(5) 제약, 한국어 에러 메시지
- `FashionSelectionSchema.styles / moods`: min(1) 제약
- `MovieSelectionSchema.releaseYear`: min(1888) 제약

**InferenceResponseSchema**
- `styleLabel`: min(1) / max(40)
- `description`: min(1)
- `music / movie / fashion` 추천 배열: max(10)
- `FashionRecommendation.price`: nonnegative, `link`: url 포맷 검증
- 모든 에러 메시지 한국어

**safeParseRequest 헬퍼**
- `InferenceRequestSchema.safeParse()` 래퍼 — Week 3 #59 API route에서 바로 사용 가능

### 테스트 결과 (선택)

`pnpm tsc --noEmit --skipLibCheck` 통과

### 리뷰 요구사항(선택)

- `moods` 최대 개수(5)와 추천 배열 최대 개수(10)는 디자인 명세 확정 전 임시값 — 확정 후 조정 필요