### PR TITLE
feat / SS-57-InferenceMocks - 도메인별 mock response 작성

### DIFF
--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -17,3 +17,10 @@ export {
   safeParseRequest,
   safeParseResponse,
 } from "./inference.schema";
+
+export {
+  mockMusicInferenceResponse,
+  mockMovieInferenceResponse,
+  mockFashionInferenceResponse,
+  getMockByDomain,
+} from "./inference.mocks";

--- a/src/lib/inference/inference.mocks.ts
+++ b/src/lib/inference/inference.mocks.ts
@@ -60,3 +60,124 @@ export const mockMusicInferenceResponse: InferenceResponse = {
     },
   ],
 };
+
+// ─── Movie ────────────────────────────────────────────────────────────────────
+
+export const mockMovieInferenceResponse: InferenceResponse = {
+  styleLabel: "시네마틱 미니멀",
+  description:
+    "미장센을 사랑하는 취향. 과잉 없이 절제된 아름다움에서 감동을 찾으며, 여백과 침묵이 만들어내는 공간에서 스타일을 표현합니다.",
+  music: [
+    {
+      id: "spotify:track:mock011",
+      name: "Experience",
+      artist: "Ludovico Einaudi",
+      image: "https://placehold.co/300x300/2f312f/faf9f6",
+      previewUrl: "https://p.scdn.co/mp3-preview/mock011",
+    },
+    {
+      id: "spotify:track:mock012",
+      name: "Comptine d'un autre été",
+      artist: "Yann Tiersen",
+      image: "https://placehold.co/300x300/2f312f/faf9f6",
+      previewUrl: null,
+    },
+  ],
+  movie: [
+    {
+      id: 2001,
+      title: "그랜드 부다페스트 호텔",
+      posterPath: "/mock/grand-budapest.jpg",
+      genres: ["코미디", "드라마", "어드벤처"],
+    },
+    {
+      id: 2002,
+      title: "파과",
+      posterPath: "/mock/the-past.jpg",
+      genres: ["드라마"],
+    },
+    {
+      id: 2003,
+      title: "콜",
+      posterPath: "/mock/call.jpg",
+      genres: ["스릴러", "미스터리"],
+    },
+  ],
+  fashion: [
+    {
+      id: "fashion:mock011",
+      name: "테일러드 울 코트",
+      image: "https://placehold.co/400x500/2f312f/faf9f6",
+      price: 198000,
+      link: "https://stylesync.example.com/shop/mock011",
+    },
+    {
+      id: "fashion:mock012",
+      name: "하이넥 슬림 니트",
+      image: "https://placehold.co/400x500/2f312f/faf9f6",
+      price: 72000,
+      link: "https://stylesync.example.com/shop/mock012",
+    },
+  ],
+};
+
+// ─── Fashion ──────────────────────────────────────────────────────────────────
+
+export const mockFashionInferenceResponse: InferenceResponse = {
+  styleLabel: "스트리트 레이어드",
+  description:
+    "자유로운 레이어링과 오버핏의 조화. 거리에서 자연스럽게 완성되는 스타일로, 실용성과 개성이 균형을 이룹니다.",
+  music: [
+    {
+      id: "spotify:track:mock021",
+      name: "HUMBLE.",
+      artist: "Kendrick Lamar",
+      image: "https://placehold.co/300x300/ff5c00/ffffff",
+      previewUrl: "https://p.scdn.co/mp3-preview/mock021",
+    },
+    {
+      id: "spotify:track:mock022",
+      name: "Nights",
+      artist: "Frank Ocean",
+      image: "https://placehold.co/300x300/ff5c00/ffffff",
+      previewUrl: null,
+    },
+  ],
+  movie: [
+    {
+      id: 3001,
+      title: "스파이더맨: 뉴 유니버스",
+      posterPath: "/mock/into-the-spider-verse.jpg",
+      genres: ["애니메이션", "액션", "어드벤처"],
+    },
+    {
+      id: 3002,
+      title: "올드보이",
+      posterPath: "/mock/oldboy.jpg",
+      genres: ["스릴러", "미스터리", "드라마"],
+    },
+  ],
+  fashion: [
+    {
+      id: "fashion:mock021",
+      name: "그래픽 후드 스웨트셔츠",
+      image: "https://placehold.co/400x500/ff5c00/ffffff",
+      price: 95000,
+      link: "https://stylesync.example.com/shop/mock021",
+    },
+    {
+      id: "fashion:mock022",
+      name: "카고 와이드 팬츠",
+      image: "https://placehold.co/400x500/ff5c00/ffffff",
+      price: 82000,
+      link: "https://stylesync.example.com/shop/mock022",
+    },
+    {
+      id: "fashion:mock023",
+      name: "청키 스니커즈",
+      image: "https://placehold.co/400x500/ff5c00/ffffff",
+      price: 145000,
+      link: "https://stylesync.example.com/shop/mock023",
+    },
+  ],
+};

--- a/src/lib/inference/inference.mocks.ts
+++ b/src/lib/inference/inference.mocks.ts
@@ -1,0 +1,62 @@
+import type { InferenceResponse } from "./inference.types";
+
+// ─── Music ────────────────────────────────────────────────────────────────────
+
+export const mockMusicInferenceResponse: InferenceResponse = {
+  styleLabel: "인디 멜랑꼴리",
+  description:
+    "감성적인 기타 리프와 몽환적인 보컬이 교차하는 인디 팝의 서정성. 고요한 도시의 밤과 개인적인 감상이 어우러지는 공간에서 자신만의 미학을 완성합니다.",
+  music: [
+    {
+      id: "spotify:track:mock001",
+      name: "Cherry Wine",
+      artist: "Hozier",
+      image: "https://placehold.co/300x300/1a1c1a/faf9f6",
+      previewUrl: "https://p.scdn.co/mp3-preview/mock001",
+    },
+    {
+      id: "spotify:track:mock002",
+      name: "Motion Sickness",
+      artist: "Phoebe Bridgers",
+      image: "https://placehold.co/300x300/1a1c1a/faf9f6",
+      previewUrl: null,
+    },
+    {
+      id: "spotify:track:mock003",
+      name: "Moon Song",
+      artist: "Phoebe Bridgers",
+      image: "https://placehold.co/300x300/1a1c1a/faf9f6",
+      previewUrl: "https://p.scdn.co/mp3-preview/mock003",
+    },
+  ],
+  movie: [
+    {
+      id: 1001,
+      title: "비포 선라이즈",
+      posterPath: "/mock/before-sunrise.jpg",
+      genres: ["로맨스", "드라마"],
+    },
+    {
+      id: 1002,
+      title: "이터널 선샤인",
+      posterPath: "/mock/eternal-sunshine.jpg",
+      genres: ["로맨스", "SF", "드라마"],
+    },
+  ],
+  fashion: [
+    {
+      id: "fashion:mock001",
+      name: "오버사이즈 데님 재킷",
+      image: "https://placehold.co/400x500/f4f3f1/1a1c1a",
+      price: 89000,
+      link: "https://stylesync.example.com/shop/mock001",
+    },
+    {
+      id: "fashion:mock002",
+      name: "스트라이프 니트 스웨터",
+      image: "https://placehold.co/400x500/f4f3f1/1a1c1a",
+      price: 65000,
+      link: "https://stylesync.example.com/shop/mock002",
+    },
+  ],
+};

--- a/src/lib/inference/inference.mocks.ts
+++ b/src/lib/inference/inference.mocks.ts
@@ -45,18 +45,12 @@ export const mockMusicInferenceResponse: InferenceResponse = {
   ],
   fashion: [
     {
-      id: "fashion:mock001",
-      name: "오버사이즈 데님 재킷",
+      keyword: "oversized denim jacket",
       image: "https://placehold.co/400x500/f4f3f1/1a1c1a",
-      price: 89000,
-      link: "https://stylesync.example.com/shop/mock001",
     },
     {
-      id: "fashion:mock002",
-      name: "스트라이프 니트 스웨터",
+      keyword: "striped knit sweater",
       image: "https://placehold.co/400x500/f4f3f1/1a1c1a",
-      price: 65000,
-      link: "https://stylesync.example.com/shop/mock002",
     },
   ],
 };
@@ -105,18 +99,12 @@ export const mockMovieInferenceResponse: InferenceResponse = {
   ],
   fashion: [
     {
-      id: "fashion:mock011",
-      name: "테일러드 울 코트",
+      keyword: "tailored wool coat",
       image: "https://placehold.co/400x500/2f312f/faf9f6",
-      price: 198000,
-      link: "https://stylesync.example.com/shop/mock011",
     },
     {
-      id: "fashion:mock012",
-      name: "하이넥 슬림 니트",
+      keyword: "turtleneck slim knit",
       image: "https://placehold.co/400x500/2f312f/faf9f6",
-      price: 72000,
-      link: "https://stylesync.example.com/shop/mock012",
     },
   ],
 };
@@ -159,25 +147,16 @@ export const mockFashionInferenceResponse: InferenceResponse = {
   ],
   fashion: [
     {
-      id: "fashion:mock021",
-      name: "그래픽 후드 스웨트셔츠",
+      keyword: "graphic hoodie sweatshirt",
       image: "https://placehold.co/400x500/ff5c00/ffffff",
-      price: 95000,
-      link: "https://stylesync.example.com/shop/mock021",
     },
     {
-      id: "fashion:mock022",
-      name: "카고 와이드 팬츠",
+      keyword: "cargo wide pants",
       image: "https://placehold.co/400x500/ff5c00/ffffff",
-      price: 82000,
-      link: "https://stylesync.example.com/shop/mock022",
     },
     {
-      id: "fashion:mock023",
-      name: "청키 스니커즈",
+      keyword: "chunky sneakers",
       image: "https://placehold.co/400x500/ff5c00/ffffff",
-      price: 145000,
-      link: "https://stylesync.example.com/shop/mock023",
     },
   ],
 };

--- a/src/lib/inference/inference.mocks.ts
+++ b/src/lib/inference/inference.mocks.ts
@@ -1,4 +1,4 @@
-import type { InferenceResponse } from "./inference.types";
+import type { Domain, InferenceResponse } from "./inference.types";
 
 // ─── Music ────────────────────────────────────────────────────────────────────
 
@@ -181,3 +181,15 @@ export const mockFashionInferenceResponse: InferenceResponse = {
     },
   ],
 };
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+const mockByDomain: Record<Domain, InferenceResponse> = {
+  music: mockMusicInferenceResponse,
+  movie: mockMovieInferenceResponse,
+  fashion: mockFashionInferenceResponse,
+};
+
+export function getMockByDomain(domain: Domain): InferenceResponse {
+  return mockByDomain[domain];
+}


### PR DESCRIPTION
## PR 제목

feat / SS-57-InferenceMocks - 도메인별 mock response 작성

## PR 본문

### 반영 브랜치

SS-57-InferenceMocks -> SS-56-InferenceZod

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

closes #57

`src/lib/inference/inference.mocks.ts` 신설.

- `mockMusicInferenceResponse` — 스타일 레이블 "인디 멜랑꼴리", `previewUrl: null` fallback 케이스 포함
- `mockMovieInferenceResponse` — 스타일 레이블 "시네마틱 미니멀"
- `mockFashionInferenceResponse` — 스타일 레이블 "스트리트 레이어드"
- `getMockByDomain(domain: Domain): InferenceResponse` 헬퍼

모든 mock은 `InferenceResponse` TypeScript 타입으로 어노테이션되어 컴파일 타임 구조 검증. Feature C 결과 페이지 shell에서 `import { mockMusicInferenceResponse } from "@/lib/inference"` 로 즉시 사용 가능.

### 테스트 결과 (선택)

`pnpm tsc --noEmit --skipLibCheck` 통과

### 리뷰 요구사항(선택)

- 런타임 `InferenceResponseSchema.parse()` 자기검증은 Week 4 #64 fixture 단계에서 추가 예정
- mock 이미지는 `placehold.co` placeholder URL 사용 (실제 에셋으로 교체 필요 없음 — 개발용)