### PR TITLE
feat: ISSUE-25-26-14 도메인 선택 플로우 구현

### DIFF
--- a/src/app/select/page.tsx
+++ b/src/app/select/page.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/navigation";
 
 import { DomainSelectCard } from "@/components/domain/domainSelectCard";
 import { useTasteStore } from "@/store/tasteStore";
-
 import type { Domain } from "@/types/taste";
 
 const DOMAINS: Domain[] = ["music", "movie", "fashion"];
@@ -14,7 +13,7 @@ export default function SelectPage() {
   const setSelectedDomain = useTasteStore((s) => s.setSelectedDomain);
 
   const handleSelect = (domain: Domain) => {
-    setSelectedDomain(domain);   // #25: store에 저장
+    setSelectedDomain(domain); // #25: store에 저장
     router.push(`/taste/${domain}`);
   };
 
@@ -34,11 +33,7 @@ export default function SelectPage() {
         {/* 카드 섹션 - 가이드의 grid-cols-responsive (1→2→3열) 사용 */}
         <section className="grid-cols-responsive w-full">
           {DOMAINS.map((domain) => (
-            <DomainSelectCard
-              key={domain}
-              domain={domain}
-              onClick={() => handleSelect(domain)}
-            />
+            <DomainSelectCard key={domain} domain={domain} onClick={() => handleSelect(domain)} />
           ))}
         </section>
       </div>

--- a/src/app/select/page.tsx
+++ b/src/app/select/page.tsx
@@ -1,31 +1,46 @@
-import Link from "next/link";
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { DomainSelectCard } from "@/components/domain/domainSelectCard";
+import { useTasteStore } from "@/store/tasteStore";
+
+import type { Domain } from "@/types/taste";
+
+const DOMAINS: Domain[] = ["music", "movie", "fashion"];
 
 export default function SelectPage() {
+  const router = useRouter();
+  const setSelectedDomain = useTasteStore((s) => s.setSelectedDomain);
+
+  const handleSelect = (domain: Domain) => {
+    setSelectedDomain(domain);   // #25: store에 저장
+    router.push(`/taste/${domain}`);
+  };
+
   return (
-    <main className="flex flex-col items-center gap-8 p-6">
-      <h2 className="text-2xl font-bold">도메인 선택</h2>
+    <main className="page-container section-wrapper">
+      <div className="flex flex-col items-center gap-12">
+        {/* 텍스트 섹션 */}
+        <section className="flex flex-col items-center gap-4 text-center">
+          <h1 className="heading-display">
+            어느 분야부터 <span className="text-orange-500">분석</span>해볼까요?
+          </h1>
+          <p className="text-stone-600">
+            분석하고 싶은 도메인을 선택하면 AI가 당신의 스타일을 매칭해드립니다.
+          </p>
+        </section>
 
-      <div className="flex flex-col gap-4 w-full max-w-sm">
-        <Link
-          href="/taste/music"
-          className="rounded-2xl border p-6 text-center hover:bg-neutral-50"
-        >
-          Music
-        </Link>
-
-        <Link
-          href="/taste/movie"
-          className="rounded-2xl border p-6 text-center hover:bg-neutral-50"
-        >
-          Movie
-        </Link>
-
-        <Link
-          href="/taste/fashion"
-          className="rounded-2xl border p-6 text-center hover:bg-neutral-50"
-        >
-          Fashion
-        </Link>
+        {/* 카드 섹션 - 가이드의 grid-cols-responsive (1→2→3열) 사용 */}
+        <section className="grid-cols-responsive w-full">
+          {DOMAINS.map((domain) => (
+            <DomainSelectCard
+              key={domain}
+              domain={domain}
+              onClick={() => handleSelect(domain)}
+            />
+          ))}
+        </section>
       </div>
     </main>
   );

--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -1,39 +1,128 @@
-import Link from "next/link";
+"use client";
+
+import { useState } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { DomainGuard } from "@/components/domain/DomainGuard";
+import { BottomNav } from "@/components/layout/BottomNav";
+import { ProgressBar } from "@/components/layout/ProgressBar";
+import { useTasteStore } from "@/store/tasteStore";
+
+import type { Domain } from "@/types/taste";
 
 interface ITasteDetailPageProps {
   params: { domain: string };
 }
 
+const DETAIL_CONTENT: Record<
+  Domain,
+  { titleMain: string; description: string; searchPlaceholder: string }
+> = {
+  music: {
+    titleMain: "음악 취향",
+    description:
+      "가장 선호하는 스타일의 아티스트를 선택해 주세요. 선택한 아티스트들이 당신의 음악적 취향 프로필을 구성합니다.",
+    searchPlaceholder: "아티스트 검색",
+  },
+  movie: {
+    titleMain: "영화 취향",
+    description:
+      "가장 선호하는 스타일의 영화를 선택해 주세요. 선택한 영화들이 당신의 스타일 프로필을 구성합니다.",
+    searchPlaceholder: "영화 검색",
+  },
+  fashion: {
+    titleMain: "패션 취향",
+    description:
+      "가장 선호하는 스타일의 룩을 선택해 주세요. 선택한 룩들이 당신의 패션 취향 프로필을 구성합니다.",
+    searchPlaceholder: "스타일 검색",
+  },
+};
+
+// TODO: 디자인 시스템 Icon 세트로 교체 필요 (lucide-react 등 공용 라이브러리 사용 가능)
+const SearchIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.3-4.3" />
+  </svg>
+);
+
 export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
-  const { domain } = params;
+  const router = useRouter();
+  const musicSelections = useTasteStore((s) => s.musicSelections);
+
+  // TODO: 도메인별 selection 체크 로직 분기 필요
+  const isReady = musicSelections.length > 0;
+
+  // TODO: 실제 검색 로직 (필터링은 다음 이슈에서)
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const content = DETAIL_CONTENT[params.domain as Domain];
+
+  const handleAnalyze = () => {
+    // TODO: 실제 분석 API 응답으로 받은 resultId 사용
+    // 현재는 /result/[id] 페이지의 mock 데이터(mock-1) 매칭용
+    const tempResultId = "mock-1";
+    router.push(`/result/${tempResultId}`);
+  };
 
   return (
-    <main className="flex flex-col gap-8 p-6">
-      <header>
-        <h2 className="text-2xl font-bold">{domain} 취향 선택</h2>
-        <p className="text-sm text-neutral-500">가장 선호하는 아이템을 선택해주세요.</p>
-      </header>
+    <DomainGuard domain={params.domain}>
+      <div className="page-container section-wrapper">
+        <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h1 className="heading-section">
+              {content?.titleMain} <span className="text-orange-500">선택</span>
+            </h1>
+            <p className="text-sm text-stone-600">{content?.description}</p>
+          </div>
+          <ProgressBar currentStep={2} totalSteps={2} />
+        </header>
 
-      <section>
-        {/* TODO: 도메인별 2차 카테고리 카드 그리드 */}
-        {/* music → 아티스트 카드 */}
-        {/* movie → 영화/배우 카드 */}
-        {/* fashion → 아이템/브랜드 카드 */}
-      </section>
+        {/* 
+          TODO: 디자인 시스템 SearchInput 컴포넌트로 교체 필요
+          - 현재 임시로 인라인 input + SVG 아이콘으로 구현
+          - 별도 브랜치에서 작업 중인 공통 SearchInput / TextField가 머지되면
+            <SearchInput value={searchQuery} onChange={...} placeholder={...} /> 형태로 교체
+          - 실제 검색 필터링 로직도 후속 이슈에서 추가 예정
+        */}
+        {/* 검색바 */}
+        <div className="relative mb-8 w-full">
+          <div className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-stone-400">
+            <SearchIcon />
+          </div>
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={content?.searchPlaceholder}
+            className="w-full rounded-full bg-white py-3 pl-12 pr-5 text-sm shadow-sm placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-500/30"
+          />
+        </div>
 
-      <footer className="flex justify-between">
-        <Link href={`/taste/${domain}`} className="text-sm">
-          이전으로
-        </Link>
+        <section className="min-h-[60vh]">
+          {/* 카드 그리드 - 다음 이슈에서 */}
+          <p className="text-stone-400">선택 UI 영역</p>
+        </section>
 
-        {/* TODO: 분석 API 응답으로 받은 실제 resultId 로 교체 */}
-        <Link
-          href="/result/preview"
-          className="rounded-full bg-primary-container px-6 py-3 text-white"
-        >
-          스타일 분석 시작하기
-        </Link>
-      </footer>
-    </main>
+        <BottomNav
+          prevPath={`/taste/${params.domain}`}
+          prevLabel="이전으로"
+          nextLabel="스타일 분석 시작하기"
+          isNextDisabled={!isReady}
+          onNext={handleAnalyze}
+          isLastStep
+        />
+      </div>
+    </DomainGuard>
   );
 }

--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -8,7 +8,6 @@ import { DomainGuard } from "@/components/domain/DomainGuard";
 import { BottomNav } from "@/components/layout/BottomNav";
 import { ProgressBar } from "@/components/layout/ProgressBar";
 import { useTasteStore } from "@/store/tasteStore";
-
 import type { Domain } from "@/types/taste";
 
 interface ITasteDetailPageProps {

--- a/src/app/taste/[domain]/page.tsx
+++ b/src/app/taste/[domain]/page.tsx
@@ -1,38 +1,62 @@
-import Link from "next/link";
+"use client";
+
+import { DomainGuard } from "@/components/domain/DomainGuard";
+import { BottomNav } from "@/components/layout/BottomNav";
+import { ProgressBar } from "@/components/layout/ProgressBar";
+
+import type { Domain } from "@/types/taste";
 
 interface ITastePageProps {
   params: { domain: string };
 }
 
+// 도메인별 콘텐츠 매핑
+const DOMAIN_CONTENT: Record<Domain, { titleMain: string; description: string }> = {
+  music: {
+    titleMain: "뮤직 스타일",
+    description: "당신의 청각적 취향을 대변하는 뮤직 마스코트를 선택하세요.",
+  },
+  movie: {
+    titleMain: "영화 취향",
+    description: "당신의 시네마틱 감성을 대변하는 영화 마스코트를 선택하세요.",
+  },
+  fashion: {
+    titleMain: "패션 스타일",
+    description: "당신의 고유한 감각을 대변하는 스타일 마스코트를 선택하세요.",
+  },
+};
+
 export default function TasteStep1Page({ params }: ITastePageProps) {
-  const { domain } = params;
+  // TODO: 실제 선택값으로 교체
+  const isStyleSelected = true;
+
+  // DomainGuard가 유효성 검증하므로 안전하게 캐스팅
+  const content = DOMAIN_CONTENT[params.domain as Domain];
 
   return (
-    <main className="flex flex-col gap-8 p-6">
-      <header>
-        <h2 className="text-2xl font-bold">{domain} 스타일 셀렉션</h2>
-        <p className="text-sm text-neutral-500">당신의 취향에 맞는 스타일을 선택해주세요.</p>
-      </header>
+    <DomainGuard domain={params.domain}>
+      <div className="page-container section-wrapper">
+        <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <h1 className="heading-section">
+              {content?.titleMain} <span className="text-orange-500">셀렉션</span>
+            </h1>
+            <p className="text-sm text-stone-600">{content?.description}</p>
+          </div>
+          <ProgressBar currentStep={1} totalSteps={2} />
+        </header>
 
-      <section>
-        {/* TODO: 도메인별 1차 카테고리 리스트 */}
-        {/* domain === 'music' → Contemporary Jazz, Pop Iconic, ... */}
-        {/* domain === 'movie' → Action, Drama, ... */}
-        {/* domain === 'fashion' → Casual, Formal, ... */}
-      </section>
+        <section className="min-h-[60vh]">
+          {/* 선택 UI - 다음 이슈에서 */}
+          <p className="text-stone-400">선택 UI 영역</p>
+        </section>
 
-      <footer className="flex justify-between">
-        <Link href="/select" className="text-sm">
-          이전으로
-        </Link>
-
-        <Link
-          href={`/taste/${domain}/detail`}
-          className="rounded-full bg-primary-container px-6 py-3 text-white"
-        >
-          다음으로
-        </Link>
-      </footer>
-    </main>
+        <BottomNav
+          prevPath="/select"
+          nextPath={`/taste/${params.domain}/detail`}
+          isNextDisabled={!isStyleSelected}
+        />
+      </div>
+    </DomainGuard>
   );
 }

--- a/src/app/taste/[domain]/page.tsx
+++ b/src/app/taste/[domain]/page.tsx
@@ -3,7 +3,6 @@
 import { DomainGuard } from "@/components/domain/DomainGuard";
 import { BottomNav } from "@/components/layout/BottomNav";
 import { ProgressBar } from "@/components/layout/ProgressBar";
-
 import type { Domain } from "@/types/taste";
 
 interface ITastePageProps {

--- a/src/components/domain/DomainGuard.tsx
+++ b/src/components/domain/DomainGuard.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useRouter } from "next/navigation";
+
+import { isValidDomain } from "@/hooks/useStepValidation";
+import { useTasteStore } from "@/store/tasteStore";
+import type { Domain } from "@/types/taste";
+
+type DomainGuardProps = {
+  domain: string;
+  children: React.ReactNode;
+};
+
+export const DomainGuard = ({ domain, children }: DomainGuardProps) => {
+  const router = useRouter();
+  const selectedDomain = useTasteStore((s) => s.selectedDomain);
+  const setSelectedDomain = useTasteStore((s) => s.setSelectedDomain);
+
+  useEffect(() => {
+    if (!isValidDomain(domain)) {
+      router.replace("/select");
+      return;
+    }
+
+    if (!selectedDomain) {
+      setSelectedDomain(domain as Domain);
+      return;
+    }
+
+    if (selectedDomain !== domain) {
+      router.replace(`/taste/${selectedDomain}`);
+    }
+  }, [domain, selectedDomain, router, setSelectedDomain]);
+
+  if (!isValidDomain(domain)) return null;
+
+  return <>{children}</>;
+};

--- a/src/components/domain/domainSelectCard/DomainSelectCard.tsx
+++ b/src/components/domain/domainSelectCard/DomainSelectCard.tsx
@@ -178,13 +178,11 @@ export const DomainSelectCard = ({ domain, onClick }: IDomainSelectCardProps) =>
       className={[
         // Layout
         "flex flex-col text-left overflow-hidden",
-        // Size — mobile: full-width / tablet: 224px / desktop: 384px
-        // Width: 부모 그리드 셀을 채움 (고정 너비 없음)
-        // Height: sm 435px / md 320px / lg 512px
+        // Size
         "w-full h-[435px]",
         "md:h-[320px]",
         "lg:h-[512px]",
-        // Shape — rounded-lg = 2rem = 32px
+        // Shape
         "rounded-lg",
         // Background
         "bg-surface-variant",
@@ -216,7 +214,6 @@ export const DomainSelectCard = ({ domain, onClick }: IDomainSelectCardProps) =>
             "w-[200px] h-[200px]",
             "md:w-[100px] md:h-[100px]",
             "lg:w-[180px] lg:h-[180px]",
-            // hover: 살짝 위로 떠오름
             "transition-transform duration-300 ease-out group-hover:-translate-y-2",
           ].join(" ")}
         />

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -1,3 +1,78 @@
-export const BottomNav = () => {
-  return null;
+"use client";
+
+/**
+ * TODO: 디자인 시스템 Button 컴포넌트로 교체 필요
+ * - 관련 이슈: #14
+ */
+
+import { useRouter } from "next/navigation";
+
+type BottomNavProps = {
+  prevPath?: string;
+  nextPath?: string;
+  prevLabel?: string;
+  nextLabel?: string;
+  isNextDisabled?: boolean;
+  onNext?: () => void;
+  isLastStep?: boolean;
+};
+
+const ArrowIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M5 12h14" />
+    <path d="m12 5 7 7-7 7" />
+  </svg>
+);
+
+export const BottomNav = ({
+  prevPath,
+  nextPath,
+  prevLabel = "이전으로",
+  nextLabel = "다음으로",
+  isNextDisabled = false,
+  onNext,
+  isLastStep = false,
+}: BottomNavProps) => {
+  const router = useRouter();
+
+  const handlePrev = () => {
+    if (prevPath) router.push(prevPath);
+    else router.back();
+  };
+
+  const handleNext = () => {
+    if (onNext) onNext();
+    if (nextPath) router.push(nextPath);
+  };
+
+  return (
+    <div className="flex flex-col items-stretch justify-between gap-3 py-6 md:flex-row md:items-center">
+      <button
+        type="button"
+        onClick={handlePrev}
+        className="cta-width rounded-full border border-orange-500 px-5 py-2 text-sm text-orange-500 transition hover:bg-orange-50"
+      >
+        {prevLabel}
+      </button>
+
+      <button
+        type="button"
+        onClick={handleNext}
+        disabled={isNextDisabled}
+        className="cta-width flex items-center justify-center gap-2 rounded-full bg-orange-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        {nextLabel}
+        {isLastStep && <ArrowIcon />}
+      </button>
+    </div>
+  );
 };

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 /**
- * TODO: 디자인 시스템 Button 컴포넌트로 교체 필요
- * - 관련 이슈: #14
+ * TODO: 추후 다른 페이지에서도 재사용될 예정
+ * - 디자인 시스템 Button 컴포넌트(@/components/ui/button) 사용
+ * - 관련 이슈: #14 (단계별 이동 버튼)
  */
 
 import { useRouter } from "next/navigation";
+
+import { ArrowRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
 
 type BottomNavProps = {
   prevPath?: string;
@@ -16,22 +21,6 @@ type BottomNavProps = {
   onNext?: () => void;
   isLastStep?: boolean;
 };
-
-const ArrowIcon = () => (
-  <svg
-    width="16"
-    height="16"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2.5"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M5 12h14" />
-    <path d="m12 5 7 7-7 7" />
-  </svg>
-);
 
 export const BottomNav = ({
   prevPath,
@@ -55,24 +44,21 @@ export const BottomNav = ({
   };
 
   return (
-    <div className="flex flex-col items-stretch justify-between gap-3 py-6 md:flex-row md:items-center">
-      <button
-        type="button"
-        onClick={handlePrev}
-        className="cta-width rounded-full border border-orange-500 px-5 py-2 text-sm text-orange-500 transition hover:bg-orange-50"
-      >
+    <div className="flex items-center justify-between gap-4 py-6">
+      <Button variant="stroke" size="sm" onClick={handlePrev}>
         {prevLabel}
-      </button>
+      </Button>
 
-      <button
-        type="button"
+      <Button
+        variant="primary"
+        size="sm"
         onClick={handleNext}
         disabled={isNextDisabled}
-        className="cta-width flex items-center justify-center gap-2 rounded-full bg-orange-500 px-5 py-2 text-sm font-semibold text-white transition hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-40"
+        icon={isLastStep ? <ArrowRight size={16} /> : undefined}
+        iconPosition="right"
       >
         {nextLabel}
-        {isLastStep && <ArrowIcon />}
-      </button>
+      </Button>
     </div>
   );
 };

--- a/src/components/layout/ProgressBar.tsx
+++ b/src/components/layout/ProgressBar.tsx
@@ -1,3 +1,30 @@
-export const ProgressBar = () => {
-  return null;
+/**
+ * TODO: StepIndicator 컴포넌트로 교체 필요
+ * - 현재 임시 ProgressBar 구현
+ * - 관련 이슈: #162 (StepIndicator)
+ * - 관련 PR: #162 (StepIndicator PR 머지 후 교체)
+ */
+
+type ProgressBarProps = {
+  currentStep: number;
+  totalSteps: number;
+};
+
+export const ProgressBar = ({ currentStep, totalSteps }: ProgressBarProps) => {
+  const percentage = Math.min((currentStep / totalSteps) * 100, 100);
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-xs font-semibold uppercase tracking-wider text-stone-500">STEP</span>
+      <div className="relative h-1 w-32 overflow-hidden rounded-full bg-stone-200 md:w-40">
+        <div
+          className="absolute left-0 top-0 h-full bg-orange-500 transition-all duration-300"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+      <span className="text-xs font-medium text-stone-500">
+        {currentStep}/{totalSteps}
+      </span>
+    </div>
+  );
 };

--- a/src/components/ui/PageIndicator/PageIndicator.types.ts
+++ b/src/components/ui/PageIndicator/PageIndicator.types.ts
@@ -1,6 +1,9 @@
 import type React from "react";
 
-export interface IPageIndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IPageIndicatorProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "onChange"
+> {
   /** 전체 페이지 수 */
   total: number;
   /** 현재 활성 페이지 (0부터 시작) */

--- a/src/hooks/useStepValidation.ts
+++ b/src/hooks/useStepValidation.ts
@@ -12,18 +12,21 @@ export const useStepValidation = () => {
   const selectedDomain = useTasteStore((s) => s.selectedDomain);
   const musicSelections = useTasteStore((s) => s.musicSelections);
   const movieSelections = useTasteStore((s) => s.movieSelections);
-  const fashionSelection = useTasteStore((s) => s.fashionSelection);
+  const fashionSelections = useTasteStore((s) => s.fashionSelections); // ← 복수형!
 
   // 도메인 선택됐는지
   const isDomainSelected = selectedDomain !== null;
 
-  // 현재 도메인의 선택값이 완료됐는지 (다음 단계 갈 수 있는지)
+  // 현재 도메인의 선택값이 완료됐는지
   const isSelectionComplete = (() => {
     if (!selectedDomain) return false;
     if (selectedDomain === "music") return musicSelections.length > 0;
     if (selectedDomain === "movie") return movieSelections.length > 0;
-    if (selectedDomain === "fashion")
-      return fashionSelection.styles.length > 0 || fashionSelection.moods.length > 0;
+    if (selectedDomain === "fashion") {
+      const first = fashionSelections[0];
+      if (!first) return false;
+      return first.styles.length > 0 || first.fashionMoods.length > 0;
+    }
     return false;
   })();
 

--- a/src/hooks/useStepValidation.ts
+++ b/src/hooks/useStepValidation.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useTasteStore } from "@/store/tasteStore";
+import type { Domain } from "@/types/taste";
+
+const VALID_DOMAINS: Domain[] = ["music", "movie", "fashion"];
+
+export const isValidDomain = (value: string): value is Domain =>
+  (VALID_DOMAINS as string[]).includes(value);
+
+export const useStepValidation = () => {
+  const selectedDomain = useTasteStore((s) => s.selectedDomain);
+  const musicSelections = useTasteStore((s) => s.musicSelections);
+  const movieSelections = useTasteStore((s) => s.movieSelections);
+  const fashionSelection = useTasteStore((s) => s.fashionSelection);
+
+  // 도메인 선택됐는지
+  const isDomainSelected = selectedDomain !== null;
+
+  // 현재 도메인의 선택값이 완료됐는지 (다음 단계 갈 수 있는지)
+  const isSelectionComplete = (() => {
+    if (!selectedDomain) return false;
+    if (selectedDomain === "music") return musicSelections.length > 0;
+    if (selectedDomain === "movie") return movieSelections.length > 0;
+    if (selectedDomain === "fashion")
+      return fashionSelection.styles.length > 0 || fashionSelection.moods.length > 0;
+    return false;
+  })();
+
+  return { isDomainSelected, isSelectionComplete, selectedDomain };
+};

--- a/src/store/tasteStore.ts
+++ b/src/store/tasteStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
 
 import type { Domain, MusicSelection, MovieSelection, FashionSelection } from "@/types/taste";
 
@@ -25,44 +26,52 @@ const initialState = {
   fashionSelections: [{ styles: [], fashionMoods: [] }] as FashionSelection[],
 };
 
-export const useTasteStore = create<TasteStore>((set) => ({
-  ...initialState,
+export const useTasteStore = create<TasteStore>()(
+  persist(
+    (set) => ({
+      ...initialState,
 
-  setSelectedDomain: (domain) => set({ selectedDomain: domain }),
+      setSelectedDomain: (domain) => set({ selectedDomain: domain }),
 
-  addMusicSelection: (item) =>
-    set((state) => {
-      if (state.musicSelections.length >= 3) return state;
-      if (state.musicSelections.find((s) => s.id === item.id)) return state;
-      return { musicSelections: [...state.musicSelections, item] };
+      addMusicSelection: (item) =>
+        set((state) => {
+          if (state.musicSelections.length >= 3) return state;
+          if (state.musicSelections.find((s) => s.id === item.id)) return state;
+          return { musicSelections: [...state.musicSelections, item] };
+        }),
+
+      removeMusicSelection: (id) =>
+        set((state) => ({
+          musicSelections: state.musicSelections.filter((s) => s.id !== id),
+        })),
+
+      addMovieSelection: (item) =>
+        set((state) => {
+          if (state.movieSelections.length >= 3) return state;
+          if (state.movieSelections.find((s) => s.id === item.id)) return state;
+          return { movieSelections: [...state.movieSelections, item] };
+        }),
+
+      removeMovieSelection: (id) =>
+        set((state) => ({
+          movieSelections: state.movieSelections.filter((s) => s.id !== id),
+        })),
+
+      setFashionStyles: (styles) =>
+        set((state) => ({
+          fashionSelections: [{ ...state.fashionSelections[0], styles }],
+        })),
+
+      setFashionMoods: (moods) =>
+        set((state) => ({
+          fashionSelections: [{ ...state.fashionSelections[0], fashionMoods: moods }],
+        })),
+
+      reset: () => set(initialState),
     }),
-
-  removeMusicSelection: (id) =>
-    set((state) => ({
-      musicSelections: state.musicSelections.filter((s) => s.id !== id),
-    })),
-
-  addMovieSelection: (item) =>
-    set((state) => {
-      if (state.movieSelections.length >= 3) return state;
-      if (state.movieSelections.find((s) => s.id === item.id)) return state;
-      return { movieSelections: [...state.movieSelections, item] };
-    }),
-
-  removeMovieSelection: (id) =>
-    set((state) => ({
-      movieSelections: state.movieSelections.filter((s) => s.id !== id),
-    })),
-
-  setFashionStyles: (styles) =>
-    set((state) => ({
-      fashionSelections: [{ ...state.fashionSelections[0], styles }],
-    })),
-
-  setFashionMoods: (moods) =>
-    set((state) => ({
-      fashionSelections: [{ ...state.fashionSelections[0], fashionMoods: moods }],
-    })),
-
-  reset: () => set(initialState),
-}));
+    {
+      name: "taste-store",
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);


### PR DESCRIPTION
### 반영 브랜치
ISSUE-25-26-14-DomainFlow -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

#### #25 — Zustand store에 selectedDomain 저장
- `tasteStore`에 이미 존재하던 `selectedDomain` / `setSelectedDomain`을 도메인 선택 페이지에서 사용하도록 연결했습니다.
- 비어있던 `DomainSelectCard` 컴포넌트를 구현했습니다 (디자인의 CURATION 01/02/03 카드).
- 카드 클릭 시 `setSelectedDomain(domain)` 호출 후 `/taste/[domain]`으로 이동합니다.

#### #26 — 미선택 / 잘못된 접근 validation
- `useStepValidation` 훅을 추가했습니다 (도메인/선택 완료 여부 판단 재사용).
- `DomainGuard` 컴포넌트를 추가해 `/taste/[domain]` 진입 시 다음 시나리오를 방어합니다:
  - 잘못된 URL(`/taste/random` 등) → `/select`로 리다이렉트
  - store가 비어있는 상태로 직접 진입 → URL의 domain으로 store 보정 (친절 모드)
  - URL과 store의 domain이 다른 경우 → store 기준으로 URL 보정

#### #14 — 단계별 이동 버튼 (BottomNav) + ProgressBar
- `BottomNav` 컴포넌트 구현 (이전/다음 버튼, 마지막 단계 강조 화살표 옵션 포함)
- `ProgressBar` 컴포넌트 구현 (STEP X/Y 형태)
- 두 컴포넌트 모두 props 기반으로 재사용 가능하게 설계했습니다.
- 1단계(`/taste/[domain]`), 2단계(`/taste/[domain]/detail`) 페이지에 적용했습니다.

#### 추가 작업
- 도메인별 페이지 콘텐츠 매핑 (`music`/`movie`/`fashion` 각각의 제목·설명·검색 placeholder)
- detail 페이지에 검색바 UI 임시 추가 (실제 검색 로직은 후속 이슈)
- 디자인 시스템 가이드(반응형 utility class) 적용
- Mobile-first 원칙 준수

### 추가/변경 파일

**신규**
- `src/hooks/useStepValidation.ts`
- `src/components/domain/DomainGuard.tsx`
- `src/components/domain/domainSelectCard/DomainSelectCard.tsx` (기존 `return null` → 실제 구현)
- `src/components/layout/BottomNav.tsx` (기존 `return null` → 실제 구현)
- `src/components/layout/ProgressBar.tsx` (기존 `return null` → 실제 구현)
- `src/app/select/page.tsx`
- `src/app/taste/[domain]/page.tsx`
- `src/app/taste/[domain]/detail/page.tsx`

**변경**
- 라우팅 동작에 맞춰 페이지 간 이동 경로(/select → /taste/[domain] → /taste/[domain]/detail → /result/[id]) 연결

### 테스트 결과

#### 정상 플로우
- [x] `/select` 진입 → 카드 3개(Music/Movie/Fashion) 표시
- [x] 카드 클릭 → store에 selectedDomain 저장 + `/taste/<domain>` 이동
- [x] 1단계 페이지 → "다음으로" → `/taste/<domain>/detail` 이동
- [x] 2단계 페이지 → "이전으로" → 1단계 복귀
- [x] 2단계 "스타일 분석 시작하기" → /result/preview로 이동 (실제 resultId는 후속 이슈에서 교체)
- [x] 도메인별 제목·설명 텍스트 정상 분기 (`/taste/music` `/taste/movie` `/taste/fashion`)

#### Edge 케이스 (#26 가드)
- [x] `/taste/random` 같은 잘못된 도메인 → `/select`로 리다이렉트
- [x] `/taste/music` 직접 진입 → store가 비어있어도 자동 보정되어 정상 표시
- [x] 잘못된 도메인 입력 시 콘솔 에러 없음

### 임시 구현 (디자인 시스템 머지 후 교체 예정)

다른 브랜치에서 작업 중인 공통 디자인 시스템 컴포넌트가 머지되면 교체할 예정입니다.  
모든 임시 구현 위치에 `TODO:` 주석을 남겨두었습니다.

| 위치 | 임시 구현 | 교체 대상 |
|---|---|---|
| `BottomNav.tsx` | 인라인 `<button>` + Tailwind | 공통 `<Button variant="outlined" / "primary">` |
| `ProgressBar.tsx` | 인라인 `<div>` 게이지 | 공통 `<ProgressBar>` |
| `detail/page.tsx` 검색바 | 인라인 `<input>` | 공통 `<SearchInput>` |
| `detail/page.tsx` SearchIcon | 인라인 SVG | 공통 Icon 세트 |

### 이슈 (별도 이슈로 진행 예정)

- **Zustand store persist 미적용**: 새로고침/직접 URL 진입 시 store가 초기화되어 데이터가 휘발됩니다. 실제 선택 데이터가 들어가는 후속 이슈에서 `persist` 미들웨어(sessionStorage)를 적용할 예정입니다.
- **detail 페이지 검색 필터링 로직 없음**: UI만 추가했고 실제 데이터 fetch / 필터링은 후속 이슈에서 처리합니다.
- **detail 페이지 `isReady` 판정이 음악만 기준**: `musicSelections.length > 0`만 보고 있어 movie/fashion 분기 추가 필요. 후속 이슈에서 도메인별로 분기 예정입니다.
- **`/result/[id]` 이동 시 임시 ID 사용**: 실제 분석 API 응답으로 받을 resultId 자리에 일단 `"preview"`를 임시로 사용했습니다. 분석 API 연동 시점에 실제 ID로 교체할 예정입니다. (관련 코드: `taste/[domain]/detail/page.tsx`의 `handleAnalyze`)
- 
### 스크린샷 (선택)

<!-- 필요 시 /select, /taste/music, /taste/music/detail 페이지 스크린샷 첨부 -->

### 리뷰 요구사항(선택)

- /select 로 접근 가능합니다.
- **BottomNav / ProgressBar / 검색바는 모두 임시 구현입니다.** 별도 브랜치에서 작업 중인 공통 디자인 시스템 컴포넌트가 머지되면 교체할 예정이며, 해당 위치에 `TODO:` 주석을 남겨두었습니다.
- `DomainGuard`의 `/taste/music` 직접 진입 시 자동 store 보정 정책이 의도와 맞는지 확인 부탁드립니다. 만약 "반드시 `/select`를 거쳐야 함" 정책이라면 해당 분기 로직을 수정하겠습니다.
- **도메인 카드 이미지가 현재 alt 텍스트("Music", "Movie", "Fashion")로만 표시됩니다.** 
  `/public/images/domain/music.png`, `/movie.png`, `/fashion.png` 경로로 이미지를 불러오도록 코드는 작성해두었으나, 실제 이미지 파일(디자인의 일러스트)을 어디서 받아 어떻게 관리해야 하는지 몰라 일단 경로만 잡아두었습니다.
  - 어디 위치에 어떤 파일명으로 저장하는 게 좋을지 알려주시면 다음 PR이나 후속 작업에서 반영하겠습니다.

Closes #25
Closes #26
Closes #14