### PR TITLE
fix: #185 MusicSelection.genre → genres 필드명 통일

### DIFF
--- a/src/types/taste.ts
+++ b/src/types/taste.ts
@@ -4,7 +4,7 @@ export type MusicSelection = {
   id: string;
   name: string;
   image: string;
-  genre: string[];
+  genres: string[];
   previewUrl: string | null;
 };
 


### PR DESCRIPTION
## Summary

`MusicSelection.genre`(단수)를 `genres`(복수)로 변경하여 `MovieSelection.genres`, `MovieRecommendation.genres`와 필드명 통일

## 변경 파일

- `src/types/taste.ts` — `genre: string[]` → `genres: string[]`

## 연쇄 수정 (SS-58 브랜치에 별도 반영 예정)

- `src/lib/inference/inference.schema.ts` — `MusicSelectionSchema.genre` → `genres`
- `src/lib/inference/inference.prompts.ts` — `s.genre` → `s.genres`

## Test plan

- [x] `pnpm type-check` 통과

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)