### PR TITLE
fix: #176 FashionSelection.moods → fashionMoods 명칭 구분

### DIFF
--- a/src/store/tasteStore.ts
+++ b/src/store/tasteStore.ts
@@ -22,7 +22,7 @@ const initialState = {
   selectedDomain: null,
   musicSelections: [],
   movieSelections: [],
-  fashionSelections: [{ styles: [], moods: [] }] as FashionSelection[],
+  fashionSelections: [{ styles: [], fashionMoods: [] }] as FashionSelection[],
 };
 
 export const useTasteStore = create<TasteStore>((set) => ({
@@ -61,7 +61,7 @@ export const useTasteStore = create<TasteStore>((set) => ({
 
   setFashionMoods: (moods) =>
     set((state) => ({
-      fashionSelections: [{ ...state.fashionSelections[0], moods }],
+      fashionSelections: [{ ...state.fashionSelections[0], fashionMoods: moods }],
     })),
 
   reset: () => set(initialState),

--- a/src/types/taste.ts
+++ b/src/types/taste.ts
@@ -19,5 +19,5 @@ export type MovieSelection = {
 
 export type FashionSelection = {
   styles: string[];
-  moods: string[];
+  fashionMoods: string[];
 };


### PR DESCRIPTION
## Summary

`InferenceRequest.moods`(크로스도메인 감성 태그)와 `FashionSelection.moods`(패션 전용 무드) 필드명 충돌 해소

## 변경 내용

- `FashionSelection.moods` → `fashionMoods` 
- `tasteStore` initialState, `setFashionMoods` 내부도 `fashionMoods`로 통일

## 두 moods의 의미 구분

| 필드 | 위치 | 의미 |
|---|---|---|
| `InferenceRequest.moods` | 최상위 | 크로스도메인 감성 태그 (예: 몽환적, 차분한) |
| `FashionSelection.fashionMoods` | selection 내부 | 패션 전용 무드 (예: 시크한, 캐주얼한) |

## 의존성

이 PR은 `fix/SS-194-FashionSelectionsArray` (#203) 머지 후 dev 기반으로 retarget됩니다.

## 후속 작업

- `inference.schema.ts` (SS-58 체인): `FashionSelectionSchema.moods` → `fashionMoods`
- `inference.prompts.ts` (SS-58 체인): `s.moods` → `s.fashionMoods`

## Test plan

- [x] `pnpm type-check` 통과

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)