### PR TITLE
fix / ISSUE-206 - InferenceResponse.styleLabel 타입 StyleLabel 객체로 수정

### DIFF
--- a/src/lib/inference/inference.types.ts
+++ b/src/lib/inference/inference.types.ts
@@ -1,3 +1,4 @@
+import type { StyleLabel } from "@/types/result";
 import type { Domain, MusicSelection, MovieSelection, FashionSelection } from "@/types/taste";
 
 // ─── Request ──────────────────────────────────────────────────────────────────
@@ -30,8 +31,11 @@ export type FashionRecommendation = {
 };
 
 export type InferenceResponse = {
-  styleLabel: string;
-  description: string;
+  /**
+   * Grok이 생성한 스타일 레이블
+   * title, description, themeColor, mood 포함
+   */
+  styleLabel: StyleLabel;
   music: MusicRecommendation[];
   movie: MovieRecommendation[];
   fashion: FashionRecommendation[];


### PR DESCRIPTION
### 반영 브랜치
ISSUE-206-FixInferenceStyleLabel -> dev

### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

closes #206

`InferenceResponse.styleLabel`이 `string`으로 정의되어 `StyleLabel` 타입과 불일치하는 문제 수정.

- `styleLabel: string` → `styleLabel: StyleLabel` 교체
- 최상위 `description` 필드 제거 (`styleLabel.description`으로 통합)
- `@/types/result`에서 `StyleLabel` import 추가

### 변경 파일

- `src/lib/inference/inference.types.ts`