### PR TITLE
feat / SS-98-SupabaseAuthClient - Supabase Auth 클라이언트 설정 (#98)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,9 @@
 
 # Supabase (https://supabase.com/dashboard/project/_/settings/api)
 NEXT_PUBLIC_SUPABASE_URL=
-NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+# deprecated: legacy anon key. 기존 로컬 환경 호환용이며, 신규 세팅에서는 비워두세요.
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=        # 서버 전용 시크릿. 브라우저에 노출 금지.
 
 # Grok AI (https://console.x.ai)

--- a/.env.example
+++ b/.env.example
@@ -3,24 +3,28 @@
 # 이 파일을 복사해서 .env.local을 만들고 값을 채워주세요.
 # cp .env.example .env.local
 # -----------------------------------------------
-# ⚠️  NEXT_PUBLIC_ 접두사 = 브라우저에 노출됨 (민감한 값 사용 금지)
-# ⚠️  그 외 변수      = 서버에서만 사용 (절대 클라이언트 코드에서 직접 참조 금지)
+# NEXT_PUBLIC_ 접두사가 붙은 변수는 브라우저에 노출됩니다.
+# 그 외 변수는 서버에서만 사용하며, 클라이언트 코드에서 직접 참조하면 안 됩니다.
 # -----------------------------------------------
 
 # Supabase (https://supabase.com/dashboard/project/_/settings/api)
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
-SUPABASE_SERVICE_ROLE_KEY=        # 서버 전용 — 절대 클라이언트에 노출 금지
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+SUPABASE_SERVICE_ROLE_KEY=        # 서버 전용 시크릿. 브라우저에 노출 금지.
 
 # Grok AI (https://console.x.ai)
-GROK_API_KEY=                     # 서버 전용
+GROK_API_KEY=                     # 서버 전용 시크릿
 
 # Spotify (https://developer.spotify.com/dashboard)
 SPOTIFY_CLIENT_ID=
-SPOTIFY_CLIENT_SECRET=            # 서버 전용
+SPOTIFY_CLIENT_SECRET=            # 서버 전용 시크릿
 
 # TMDB (https://www.themoviedb.org/settings/api)
-TMDB_API_KEY=                     # 서버 전용
+TMDB_API_KEY=                     # 서버 전용 시크릿
 
 # Unsplash (https://unsplash.com/developers)
-UNSPLASH_ACCESS_KEY=              # 서버 전용
+UNSPLASH_ACCESS_KEY=              # 서버 전용 시크릿
+
+# 앱 설정
+NEXT_PUBLIC_SITE_URL=http://localhost:3000

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,10 +1,15 @@
 import { createBrowserClient } from "@supabase/ssr";
 
 export const createSupabaseBrowserClient = () => {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
-  );
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabasePublishableKey =
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabasePublishableKey) {
+    throw new Error("Missing Supabase browser environment variables");
+  }
+
+  return createBrowserClient(supabaseUrl, supabasePublishableKey);
 };
 
 export const createClient = () => {

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,12 +1,12 @@
 import { createBrowserClient } from "@supabase/ssr";
 
-/**
- * 브라우저(Client Component)용 Supabase 클라이언트
- * "use client" 컴포넌트 또는 커스텀 훅 내부에서 사용
- */
-export function createClient() {
+export const createSupabaseBrowserClient = () => {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
   );
-}
+};
+
+export const createClient = () => {
+  return createSupabaseBrowserClient();
+};

--- a/src/lib/supabase/index.ts
+++ b/src/lib/supabase/index.ts
@@ -1,0 +1,2 @@
+export * from "./client";
+export * from "./server";

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -4,23 +4,24 @@ import { createServerClient } from "@supabase/ssr";
 
 export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabasePublishableKey =
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
-    {
-      cookies: {
-        getAll: () => cookieStore.getAll(),
-        setAll: (cookiesToSet) => {
-          try {
-            cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
-            );
-          } catch {}
-        },
+  if (!supabaseUrl || !supabasePublishableKey) {
+    throw new Error("Missing Supabase server environment variables");
+  }
+
+  return createServerClient(supabaseUrl, supabasePublishableKey, {
+    cookies: {
+      getAll: () => cookieStore.getAll(),
+      setAll: (cookiesToSet) => {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options));
+        } catch {}
       },
-    }
-  );
+    },
+  });
 }
 
 export async function createServerSupabaseClient() {

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -2,15 +2,12 @@ import { cookies } from "next/headers";
 
 import { createServerClient } from "@supabase/ssr";
 
-/**
- * 서버(Server Component / Route Handler / Server Action)용 Supabase 클라이언트
- * 서버 컨텍스트에서만 호출 가능 (next/headers 사용)
- */
-export async function createServerSupabaseClient() {
+export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
+
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
       cookies: {
         getAll: () => cookieStore.getAll(),
@@ -24,4 +21,8 @@ export async function createServerSupabaseClient() {
       },
     }
   );
+}
+
+export async function createServerSupabaseClient() {
+  return createSupabaseServerClient();
 }


### PR DESCRIPTION
## 반영 브랜치
SS-98-SupabaseAuthClient -> dev

## PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 업데이트

## 작업 내용
- Supabase 프로젝트 URL과 Publishable Key를 기준으로 Auth 클라이언트 설정 구성
- 브라우저 & 서버 환경 Supabase 클라이언트 유틸 정리
- `src/lib/supabase/index.ts`를 추가해 공용 import 경로 정리
- `.env.example`의 Supabase 환경 변수 키를 `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` 기준으로 정리

## 테스트 결과 (선택)
- `pnpm type-check` 통과
- Supabase 대시보드에서 Email Provider 활성화 확인
- Supabase 대시보드에서 Site URL 로컬 개발 주소 설정 확인

## 스크린샷 (선택)

## 리뷰 요구사항 (선택)