### PR TITLE
feat / SS-72-ResultPage - 결과 페이지 Week3 (StyleLabelHero · loading/error · audio player · equalizer)

### DIFF
--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -96,7 +96,7 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
                 전체 플레이리스트
               </span>
             </div>
-            <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:overflow-visible">
+            <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:overflow-visible xl:gap-6">
               {music.map((track) => (
                 <div key={track.id} className="min-w-[220px] flex-shrink-0 md:min-w-0">
                   <RecommendCard
@@ -122,7 +122,7 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
                 CINEMATIC MOOD
               </h2>
             </div>
-            <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:overflow-visible">
+            <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:overflow-visible xl:gap-6">
               {movie.map((m) => (
                 <div key={m.id} className="min-w-[220px] flex-shrink-0 md:min-w-0">
                   <RecommendCard
@@ -143,7 +143,7 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
                 FASHION MOOD
               </h2>
             </div>
-            <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:overflow-visible">
+            <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:overflow-visible xl:gap-6">
               {fashion.map((item, i) => (
                 <div key={i} className="min-w-[220px] flex-shrink-0 md:min-w-0">
                   <RecommendCard

--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -1,7 +1,15 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
 import { RecommendCard } from "@/components/result/recommendCard";
+import { ResultPageError } from "@/components/result/ResultPageError";
+import { ResultPageSkeleton } from "@/components/result/ResultPageSkeleton";
 import { ShareCard } from "@/components/result/shareCard";
+import { StyleLabelHero } from "@/components/result/styleLabel";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/Icon";
+import { useAudioPlayer } from "@/hooks/useAudioPlayer";
 import type { StyleResult } from "@/types/result";
 
 // X(Twitter) 아이콘 — Icon 레지스트리에 없어서 인라인 처리
@@ -21,41 +29,21 @@ const MOCK_RESULT: StyleResult = {
     themeColor: "#e6e6fa",
     mood: { energy: "low", tone: "dark", aesthetic: "indie" },
   },
-  recommendations: {
-    music: [
-      { id: "1", name: "Blonde", artist: "Frank Ocean", image: "", previewUrl: null },
-      { id: "2", name: "Ivy", artist: "Frank Ocean", image: "", previewUrl: null },
-      { id: "3", name: "Nights", artist: "Frank Ocean", image: "", previewUrl: null },
-    ],
-    movies: [
-      { id: 1, title: "Call Me By Your Name", posterPath: "", genres: ["Drama", "Romance"] },
-      { id: 2, title: "Moonlight", posterPath: "", genres: ["Drama"] },
-      { id: 3, title: "Lost in Translation", posterPath: "", genres: ["Drama"] },
-    ],
-    fashion: [
-      {
-        id: "1",
-        keyword: "Oversized Earth Tone Coat",
-        image: "",
-        photographerName: "John Doe",
-        photographerUrl: "",
-      },
-      {
-        id: "2",
-        keyword: "Minimal Monochrome Set",
-        image: "",
-        photographerName: "Jane Doe",
-        photographerUrl: "",
-      },
-      {
-        id: "3",
-        keyword: "Soft Denim Layer",
-        image: "",
-        photographerName: "Alex Kim",
-        photographerUrl: "",
-      },
-    ],
-  },
+  music: [
+    { id: "1", name: "Blonde", artist: "Frank Ocean", image: "", previewUrl: null },
+    { id: "2", name: "Ivy", artist: "Frank Ocean", image: "", previewUrl: null },
+    { id: "3", name: "Nights", artist: "Frank Ocean", image: "", previewUrl: null },
+  ],
+  movie: [
+    { id: 1, title: "Call Me By Your Name", posterPath: "", genres: ["Drama", "Romance"] },
+    { id: 2, title: "Moonlight", posterPath: "", genres: ["Drama"] },
+    { id: 3, title: "Lost in Translation", posterPath: "", genres: ["Drama"] },
+  ],
+  fashion: [
+    { keyword: "Oversized Earth Tone Coat", image: "" },
+    { keyword: "Minimal Monochrome Set", image: "" },
+    { keyword: "Soft Denim Layer", image: "" },
+  ],
   createdAt: new Date().toISOString(),
 };
 
@@ -67,57 +55,34 @@ interface IResultPageProps {
 
 export default function ResultPage({ params: _params }: IResultPageProps) {
   // TODO: _params.id로 API에서 실제 데이터 fetch
-  const { styleLabel, recommendations } = MOCK_RESULT;
+  const [isLoading] = useState(false);
+  const [error] = useState<string | null>(null);
 
-  // "Melancholic Softboy" → "MELANCHOLIC\nSOFTBOY"
-  const words = styleLabel.title.toUpperCase().split(" ");
-  const mid = Math.ceil(words.length / 2);
-  const titleFormatted = [words.slice(0, mid).join(" "), words.slice(mid).join(" ")]
-    .filter(Boolean)
-    .join("\n");
+  const { styleLabel, music, movie, fashion } = MOCK_RESULT;
+  const { playingUrl, isPlaying: isAudioPlaying, toggle } = useAudioPlayer();
+
+  const handleReanalyze = useCallback(() => {
+    // TODO: 재분석 플로우 연결
+  }, []);
+
+  const handleShareCard = useCallback(() => {
+    // TODO: 공유 카드 모달 연결
+  }, []);
+
+  if (isLoading) return <ResultPageSkeleton />;
+  if (error) return <ResultPageError message={error} />;
 
   return (
     <div className="bg-background">
       <div className="mx-auto px-4 md:px-9 lg:px-[120px] max-w-[1280px] py-12 lg:py-20">
-        {/* ── Hero Section ──────────────────────────────────────────────────── */}
-        <section className="flex flex-col lg:flex-row lg:items-center gap-10 mb-16 lg:mb-20">
-          {/* 텍스트 영역 */}
-          <div className="flex flex-col items-center lg:items-start gap-6 flex-1">
-            {/* 배지 */}
-            <span className="inline-block px-4 py-1 rounded-full bg-primary-container/10 font-korean font-medium text-body-sm text-primary-container">
-              • 에스테틱 큐레이션 완료
-            </span>
-
-            {/* H1 — 390px: 48px center / 768px+: 72px center / 1920px: 72px left */}
-            <h1 className="font-headline font-black text-display-sm md:text-display-lg text-on-background uppercase leading-none tracking-tighter whitespace-pre-line text-center lg:text-left">
-              {titleFormatted}
-            </h1>
-
-            {/* 설명 — 390px: Regular 16px center / 768px+: Bold 20px center / lg: Bold 20px left */}
-            <p className="font-korean font-normal text-body-md text-on-surface-variant keep-all text-center lg:text-left lg:font-bold lg:text-title-lg max-w-[480px] md:font-bold md:text-title-lg">
-              {styleLabel.description}
-            </p>
-
-            {/* 버튼 */}
-            <div className="flex flex-wrap justify-center lg:justify-start gap-3">
-              <Button variant="stroke" size="sm">
-                다시 분석하기
-              </Button>
-              <Button variant="primary" size="sm">
-                공유 카드 만들기
-              </Button>
-            </div>
-          </div>
-
-          {/* 캐릭터 플레이스홀더 — TODO: #88 캐릭터 컴포넌트 완성 후 교체 */}
-          <div className="flex justify-center lg:justify-end flex-shrink-0">
-            <div
-              className="w-[336px] h-[336px] lg:w-[320px] lg:h-[320px]"
-              style={{ background: styleLabel.themeColor, borderRadius: "64px" }}
-              aria-hidden="true"
-            />
-          </div>
-        </section>
+        {/* ── Hero Section (#72) ────────────────────────────────────────────── */}
+        <StyleLabelHero
+          title={styleLabel.title}
+          description={styleLabel.description}
+          themeColor={styleLabel.themeColor}
+          onReanalyze={handleReanalyze}
+          onShareCard={handleShareCard}
+        />
 
         {/* ── Domain Sections ───────────────────────────────────────────────── */}
         <div className="flex flex-col gap-16 lg:gap-20 mb-16 lg:mb-20">
@@ -131,9 +96,8 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
                 전체 플레이리스트
               </span>
             </div>
-            {/* 390px: 가로 스크롤 / md+: 3열 그리드 */}
             <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:overflow-visible">
-              {recommendations.music.map((track) => (
+              {music.map((track) => (
                 <div key={track.id} className="min-w-[220px] flex-shrink-0 md:min-w-0">
                   <RecommendCard
                     domain="music"
@@ -141,6 +105,10 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
                     subtitle={track.artist}
                     imageUrl={track.image || undefined}
                     previewUrl={track.previewUrl}
+                    isPlaying={
+                      isAudioPlaying && playingUrl === track.previewUrl && track.previewUrl !== null
+                    }
+                    onPreviewClick={track.previewUrl ? () => toggle(track.previewUrl!) : undefined}
                   />
                 </div>
               ))}
@@ -155,13 +123,13 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
               </h2>
             </div>
             <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:overflow-visible">
-              {recommendations.movies.map((movie) => (
-                <div key={movie.id} className="min-w-[220px] flex-shrink-0 md:min-w-0">
+              {movie.map((m) => (
+                <div key={m.id} className="min-w-[220px] flex-shrink-0 md:min-w-0">
                   <RecommendCard
                     domain="movie"
-                    title={movie.title}
-                    subtitle={movie.genres.join(" · ")}
-                    imageUrl={movie.posterPath || undefined}
+                    title={m.title}
+                    subtitle={m.genres.join(" · ")}
+                    imageUrl={m.posterPath || undefined}
                   />
                 </div>
               ))}
@@ -176,8 +144,8 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
               </h2>
             </div>
             <div className="flex gap-4 overflow-x-auto pb-2 md:grid md:grid-cols-3 md:overflow-visible">
-              {recommendations.fashion.map((item) => (
-                <div key={item.id} className="min-w-[220px] flex-shrink-0 md:min-w-0">
+              {fashion.map((item, i) => (
+                <div key={i} className="min-w-[220px] flex-shrink-0 md:min-w-0">
                   <RecommendCard
                     domain="fashion"
                     title={item.keyword}
@@ -191,7 +159,6 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
 
         {/* ── Export Identity Section ───────────────────────────────────────── */}
         <section className="relative overflow-hidden bg-on-background rounded-[48px] p-6 md:p-10 lg:p-24 mb-4 lg:mb-6">
-          {/* 배경 장식 텍스트 */}
           <div
             className="absolute top-[156px] left-0 pointer-events-none select-none whitespace-nowrap"
             aria-hidden="true"
@@ -202,7 +169,6 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
           </div>
 
           <div className="relative flex flex-col lg:flex-row lg:gap-24 lg:items-center">
-            {/* 텍스트 + 버튼 */}
             <div className="flex flex-col gap-6 lg:w-[376px] flex-shrink-0 mb-10 lg:mb-0">
               <h2 className="font-headline font-black text-white text-display-sm lg:text-display-lg leading-none uppercase">
                 EXPORT
@@ -238,18 +204,17 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
                 themeColor={styleLabel.themeColor}
                 mood={styleLabel.mood}
                 music={{
-                  title: recommendations.music[0]?.name ?? "",
-                  artist: recommendations.music[0]?.artist ?? "",
+                  title: music[0]?.name ?? "",
+                  artist: music[0]?.artist ?? "",
                 }}
-                movie={{ title: recommendations.movies[0]?.title ?? "" }}
-                fashion={{ keyword: recommendations.fashion[0]?.keyword ?? "" }}
+                movie={{ title: movie[0]?.title ?? "" }}
+                fashion={{ keyword: fashion[0]?.keyword ?? "" }}
               />
             </div>
           </div>
         </section>
 
         {/* ── Guest Save Banner ─────────────────────────────────────────────── */}
-        {/* 390px: flex-col center / md+: flex-row 116px */}
         <section className="flex flex-col items-center gap-4 text-center bg-surface-variant rounded-[24px] px-8 py-8 md:flex-row md:items-center md:justify-between md:text-left md:py-0 md:h-[116px]">
           <div className="flex flex-col items-center gap-2 md:flex-row md:gap-3">
             <span className="text-[24px]" aria-hidden="true">

--- a/src/components/result/ResultPageError.tsx
+++ b/src/components/result/ResultPageError.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+interface IResultPageErrorProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export const ResultPageError = ({
+  message = "결과를 불러오는 중 문제가 발생했어요.",
+  onRetry,
+}: IResultPageErrorProps) => (
+  <div className="bg-background min-h-[60vh] flex flex-col items-center justify-center gap-6 px-4 text-center">
+    <p className="font-korean text-title-lg text-on-background keep-all">{message}</p>
+    {onRetry && (
+      <Button variant="stroke" size="sm" onClick={onRetry}>
+        다시 시도하기
+      </Button>
+    )}
+  </div>
+);

--- a/src/components/result/ResultPageSkeleton.tsx
+++ b/src/components/result/ResultPageSkeleton.tsx
@@ -1,0 +1,37 @@
+export const ResultPageSkeleton = () => (
+  <div className="bg-background animate-pulse">
+    <div className="mx-auto px-4 md:px-9 lg:px-[120px] max-w-[1280px] py-12 lg:py-20">
+      {/* Hero skeleton */}
+      <div className="flex flex-col lg:flex-row lg:items-center gap-10 mb-16 lg:mb-20">
+        <div className="flex flex-col items-center lg:items-start gap-6 flex-1">
+          <div className="h-6 w-40 rounded-full bg-surface-variant" />
+          <div className="flex flex-col gap-3 w-full">
+            <div className="h-14 w-3/4 rounded-lg bg-surface-variant" />
+            <div className="h-14 w-1/2 rounded-lg bg-surface-variant" />
+          </div>
+          <div className="h-5 w-full max-w-[480px] rounded bg-surface-variant" />
+          <div className="h-5 w-2/3 max-w-[480px] rounded bg-surface-variant" />
+          <div className="flex gap-3">
+            <div className="h-9 w-28 rounded-full bg-surface-variant" />
+            <div className="h-9 w-32 rounded-full bg-surface-variant" />
+          </div>
+        </div>
+        <div className="w-[336px] h-[336px] lg:w-[320px] lg:h-[320px] rounded-[64px] bg-surface-variant flex-shrink-0 mx-auto lg:mx-0" />
+      </div>
+
+      {/* Domain sections skeleton */}
+      <div className="flex flex-col gap-16 lg:gap-20 mb-16 lg:mb-20">
+        {[0, 1, 2].map((i) => (
+          <div key={i}>
+            <div className="h-8 w-48 rounded bg-surface-variant mb-6 lg:mb-8" />
+            <div className="grid grid-cols-3 gap-4">
+              {[0, 1, 2].map((j) => (
+                <div key={j} className="h-[340px] rounded-[2.5rem] bg-surface-variant" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/result/recommendCard/EqualizerBars.tsx
+++ b/src/components/result/recommendCard/EqualizerBars.tsx
@@ -1,0 +1,34 @@
+interface IEqualizerBarsProps {
+  /** 막대 크기 — sm: 버튼 안 / lg: 앨범아트 중앙 */
+  size?: "sm" | "lg";
+  /** 막대 색상 (Tailwind bg-* 클래스). 기본 currentColor 사용 */
+  className?: string;
+}
+
+const BAR_DELAYS_MS = [0, 150, 300, 450, 600];
+
+const SIZE_CONFIG = {
+  sm: { wrap: "h-3 gap-[2px]", bar: "w-[2px] h-full", count: 3 },
+  lg: { wrap: "h-12 gap-1.5", bar: "w-2 h-full rounded-full", count: 5 },
+} as const;
+
+/**
+ * 음악 재생 중 시각화용 이퀄라이저. 각 막대가 다른 delay로 위아래 스케일 애니메이션.
+ * - sm: 버튼 안 (3 bars, height 12px)
+ * - lg: 앨범아트 중앙 (5 bars, height 48px)
+ */
+export const EqualizerBars = ({ size = "sm", className = "" }: IEqualizerBarsProps) => {
+  const { wrap, bar, count } = SIZE_CONFIG[size];
+
+  return (
+    <div className={`inline-flex items-end ${wrap} ${className}`} role="img" aria-label="재생 중">
+      {Array.from({ length: count }).map((_, i) => (
+        <span
+          key={i}
+          className={`${bar} bg-current animate-eq-bar origin-bottom inline-block`}
+          style={{ animationDelay: `${BAR_DELAYS_MS[i % BAR_DELAYS_MS.length]}ms` }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/result/recommendCard/RecommendCard.tsx
+++ b/src/components/result/recommendCard/RecommendCard.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 
 import { Icon } from "@/components/ui/Icon";
 
+import { EqualizerBars } from "./EqualizerBars";
 import { recommendCardVariants } from "./recommendCard.variants";
 
 import type { IRecommendCardProps } from "./recommendCard.types";
@@ -35,6 +36,16 @@ const MusicCardContent = ({
           ) : (
             <div className="w-full h-full flex items-center justify-center">
               <Icon name="music" className="text-white/50" size={48} />
+            </div>
+          )}
+
+          {/* 재생 중 overlay + equalizer */}
+          {isPlaying && (
+            <div
+              className="absolute inset-0 flex items-center justify-center bg-black/55 backdrop-blur-[2px] text-white"
+              aria-hidden="true"
+            >
+              <EqualizerBars size="lg" />
             </div>
           )}
         </div>
@@ -71,14 +82,11 @@ const MusicCardContent = ({
           ].join(" ")}
         >
           {isPlaying ? (
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
-              <rect x="2" y="1.5" width="3" height="9" rx="0.75" />
-              <rect x="7" y="1.5" width="3" height="9" rx="0.75" />
-            </svg>
+            <EqualizerBars size="sm" className="text-on-background" />
           ) : (
             <Icon name="play" size={12} />
           )}
-          <span className="tracking-widest uppercase">{isPlaying ? "PAUSE" : "30S PREVIEW"}</span>
+          <span className="tracking-widest uppercase">{isPlaying ? "PLAYING" : "30S PREVIEW"}</span>
         </button>
       </div>
     </>

--- a/src/components/result/recommendCard/RecommendCard.tsx
+++ b/src/components/result/recommendCard/RecommendCard.tsx
@@ -16,9 +16,10 @@ const MusicCardContent = ({
   imageUrl,
   previewUrl,
   onPreviewClick,
+  isPlaying,
 }: Pick<
   IRecommendCardProps,
-  "title" | "subtitle" | "imageUrl" | "previewUrl" | "onPreviewClick"
+  "title" | "subtitle" | "imageUrl" | "previewUrl" | "onPreviewClick" | "isPlaying"
 >) => {
   const hasPreview = Boolean(previewUrl);
 
@@ -69,8 +70,15 @@ const MusicCardContent = ({
               : "bg-surface/40 cursor-not-allowed opacity-50",
           ].join(" ")}
         >
-          <Icon name="play" size={12} />
-          <span className="tracking-widest uppercase">30S PREVIEW</span>
+          {isPlaying ? (
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true">
+              <rect x="2" y="1.5" width="3" height="9" rx="0.75" />
+              <rect x="7" y="1.5" width="3" height="9" rx="0.75" />
+            </svg>
+          ) : (
+            <Icon name="play" size={12} />
+          )}
+          <span className="tracking-widest uppercase">{isPlaying ? "PAUSE" : "30S PREVIEW"}</span>
         </button>
       </div>
     </>
@@ -127,6 +135,7 @@ export const RecommendCard = ({
   imageUrl,
   previewUrl,
   onPreviewClick,
+  isPlaying,
 }: IRecommendCardProps) => {
   const variant = recommendCardVariants[domain];
   const isDark = domain === "movie" || domain === "fashion";
@@ -152,6 +161,7 @@ export const RecommendCard = ({
           imageUrl={imageUrl}
           previewUrl={previewUrl}
           onPreviewClick={onPreviewClick}
+          isPlaying={isPlaying}
         />
       )}
     </article>

--- a/src/components/result/recommendCard/recommendCard.types.ts
+++ b/src/components/result/recommendCard/recommendCard.types.ts
@@ -12,4 +12,6 @@ export interface IRecommendCardProps {
   previewUrl?: string | null;
   /** 미리듣기 버튼 클릭 핸들러 — music 전용 */
   onPreviewClick?: () => void;
+  /** 현재 이 카드가 재생 중 여부 — music 전용 */
+  isPlaying?: boolean;
 }

--- a/src/components/result/styleLabel/StyleLabelHero.tsx
+++ b/src/components/result/styleLabel/StyleLabelHero.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export interface IStyleLabelHeroProps {
+  title: string;
+  description: string;
+  themeColor: string;
+  onReanalyze?: () => void;
+  onShareCard?: () => void;
+}
+
+export const StyleLabelHero = ({
+  title,
+  description,
+  themeColor,
+  onReanalyze,
+  onShareCard,
+}: IStyleLabelHeroProps) => {
+  // "Melancholic Softboy" → "MELANCHOLIC\nSOFTBOY"
+  const words = title.toUpperCase().split(" ");
+  const mid = Math.ceil(words.length / 2);
+  const titleFormatted = [words.slice(0, mid).join(" "), words.slice(mid).join(" ")]
+    .filter(Boolean)
+    .join("\n");
+
+  return (
+    <section className="flex flex-col lg:flex-row lg:items-center gap-10 mb-16 lg:mb-20">
+      {/* 텍스트 영역 */}
+      <div className="flex flex-col items-center lg:items-start gap-6 flex-1">
+        <span className="inline-block px-4 py-1 rounded-full bg-primary-container/10 font-korean font-medium text-body-sm text-primary-container">
+          • 에스테틱 큐레이션 완료
+        </span>
+
+        <h1 className="font-headline font-black text-display-sm md:text-display-lg text-on-background uppercase leading-none tracking-tighter whitespace-pre-line text-center lg:text-left">
+          {titleFormatted}
+        </h1>
+
+        <p className="font-korean font-normal text-body-md text-on-surface-variant keep-all text-center lg:text-left lg:font-bold lg:text-title-lg max-w-[480px] md:font-bold md:text-title-lg">
+          {description}
+        </p>
+
+        <div className="flex flex-wrap justify-center lg:justify-start gap-3">
+          <Button variant="stroke" size="sm" onClick={onReanalyze}>
+            다시 분석하기
+          </Button>
+          <Button variant="primary" size="sm" onClick={onShareCard}>
+            공유 카드 만들기
+          </Button>
+        </div>
+      </div>
+
+      {/* 캐릭터 플레이스홀더 — TODO: #88 캐릭터 컴포넌트 완성 후 교체 */}
+      <div className="flex justify-center lg:justify-end flex-shrink-0">
+        <div
+          className="w-[336px] h-[336px] lg:w-[320px] lg:h-[320px]"
+          style={{ background: themeColor, borderRadius: "64px" }}
+          aria-hidden="true"
+        />
+      </div>
+    </section>
+  );
+};

--- a/src/components/result/styleLabel/index.ts
+++ b/src/components/result/styleLabel/index.ts
@@ -1,1 +1,3 @@
 export { StyleLabel } from "./StyleLabel";
+export { StyleLabelHero } from "./StyleLabelHero";
+export type { IStyleLabelHeroProps } from "./StyleLabelHero";

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface IUseAudioPlayerReturn {
+  /** 현재 재생 중인 previewUrl. null이면 재생 없음 */
+  playingUrl: string | null;
+  /** 재생 중 여부 */
+  isPlaying: boolean;
+  /** 재생 / 일시정지 토글. 동일 URL이면 토글, 다른 URL이면 교체 재생 */
+  toggle: (url: string) => void;
+  /** 재생 중단 */
+  stop: () => void;
+}
+
+export function useAudioPlayer(): IUseAudioPlayerReturn {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [playingUrl, setPlayingUrl] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const handleEnded = useCallback(() => {
+    setIsPlaying(false);
+    setPlayingUrl(null);
+  }, []);
+
+  const stop = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+    }
+    setIsPlaying(false);
+    setPlayingUrl(null);
+  }, []);
+
+  const toggle = useCallback(
+    (url: string) => {
+      // 동일 URL — 재생/일시정지 토글
+      if (playingUrl === url) {
+        if (isPlaying) {
+          audioRef.current?.pause();
+          setIsPlaying(false);
+        } else {
+          audioRef.current?.play();
+          setIsPlaying(true);
+        }
+        return;
+      }
+
+      // 다른 URL — 기존 정지 후 새로 재생
+      stop();
+
+      const audio = new Audio(url);
+      audio.addEventListener("ended", handleEnded);
+      audioRef.current = audio;
+      audio.play().catch(() => {
+        setIsPlaying(false);
+        setPlayingUrl(null);
+      });
+      setPlayingUrl(url);
+      setIsPlaying(true);
+    },
+    [playingUrl, isPlaying, stop, handleEnded]
+  );
+
+  // 언마운트 시 재생 중단
+  useEffect(() => {
+    return () => {
+      audioRef.current?.pause();
+    };
+  }, []);
+
+  return { playingUrl, isPlaying, toggle, stop };
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -91,9 +91,15 @@ const config: Config = {
           "0%, 100%": { transform: "scaleY(1)" },
           "45%, 55%": { transform: "scaleY(0.05)" },
         },
+        // Equalizer bar — 재생 중 시각화. transform-origin: bottom 으로 아래에서 차오름.
+        eqBar: {
+          "0%, 100%": { transform: "scaleY(0.3)" },
+          "50%": { transform: "scaleY(1)" },
+        },
       },
       animation: {
         wink: "wink 0.5s ease-in-out",
+        "eq-bar": "eqBar 0.9s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
## 반영 브랜치
`SS-72-ResultPage` → `dev`

## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용
- **#72 StyleLabelHero 컴포넌트 추출**: 결과 페이지 히어로 섹션(배지/제목 2줄/설명/CTA)을 재사용 가능한 컴포넌트로 분리
- **#73 로딩/에러 상태 컴포넌트**: `ResultPageSkeleton`, `ResultPageError` 추가 — 데이터 fetch 단계에서 사용할 수 있도록 페이지에서 분기 처리
- **#75 useAudioPlayer 훅**: 30초 미리듣기 재생/일시정지 토글, 한 번에 한 곡만 재생, 언마운트 시 정리
- **#68 RecommendCard 오디오 연동 + 시각화**:
  - `isPlaying` prop 추가, 재생 중 앨범아트 위에 검정 overlay + 큰 이퀄라이저 5개 막대 표시
  - 버튼 라벨 \"30S PREVIEW\" → \"PLAYING\" + 작은 이퀄라이저 3개 막대로 전환
  - 새 `EqualizerBars` 컴포넌트 (sm / lg 사이즈), `eqBar` tailwind keyframes 추가
- 결과 페이지 카드 그리드: xl(1920+) 화면에서 gap을 `1rem` → `1.5rem` 으로 확대

## 테스트 결과
- `tsc --noEmit` 통과
- 로컬에서 재생 토글, 다른 카드 전환(단일 재생 보장), previewUrl null 카드 disabled 동작 확인
- 검증 중 발견한 버그 1건 수정: 페이지가 훅의 `isPlaying`을 사용하지 않아 일시정지 후에도 PAUSE 상태가 유지되던 문제

## 리뷰 요구사항
- 이퀄라이저 시각화 톤(앨범아트 overlay 강도, 막대 크기/속도) 피드백 받고 싶습니다
- 카드 배경 톤(현재 `bg-surface-variant`)이 페이지 배경과 차이가 작아 살짝 묻히는 느낌인데, 이번 PR 범위 밖으로 분리해도 될지 의견 부탁드려요

Closes #72
Closes #73
Closes #75
Closes #68