### PR TITLE
feat / SS-99-AuthFormUI - 로그인 랜딩 및 인증 폼 UI 구성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,17 @@
 # -----------------------------------------------
-# StyleSync 환경변수 예시 파일
-# 이 파일을 .env.local로 복사한 뒤 값을 채워주세요.
+# StyleSync environment template
+# Copy this file to .env.local and fill in the values.
 # cp .env.example .env.local
 # -----------------------------------------------
-# NEXT_PUBLIC_ 접두사가 붙은 값은 브라우저에 노출됩니다.
-# 나머지 값은 서버 전용으로만 사용하고, 실제 시크릿은 커밋하지 않습니다.
+# NEXT_PUBLIC_ values are exposed to the browser.
+# Keep all other values server-only and never commit real secrets.
 # -----------------------------------------------
 
 # Supabase
 # https://supabase.com/dashboard/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
-# 기존 로컬 설정과의 호환을 위한 레거시 fallback 키입니다.
+# Legacy fallback for older local setups.
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,17 @@
 # -----------------------------------------------
-# StyleSync environment template
-# Copy this file to .env.local and fill in the values.
+# StyleSync 환경변수 예시 파일
+# 이 파일을 .env.local로 복사한 뒤 값을 채워주세요.
 # cp .env.example .env.local
 # -----------------------------------------------
-# NEXT_PUBLIC_ values are exposed to the browser.
-# Keep all other values server-only and never commit real secrets.
+# NEXT_PUBLIC_ 접두사가 붙은 값은 브라우저에 노출됩니다.
+# 나머지 값은 서버 전용으로만 사용하고, 실제 시크릿은 커밋하지 않습니다.
 # -----------------------------------------------
 
 # Supabase
 # https://supabase.com/dashboard/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
-# Legacy fallback for older local setups.
+# 기존 로컬 설정과의 호환을 위한 레거시 fallback 키입니다.
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,3 +1,5 @@
+import { AuthLanding } from "@/components/auth/authLanding/AuthLanding";
+
 export default function LoginPage() {
-  return <div>로그인</div>;
+  return <AuthLanding />;
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,3 +1,86 @@
+import { AuthSplitLayout } from "@/components/auth/authSplitLayout";
+
+const signupFields = [
+  {
+    id: "email",
+    name: "email",
+    type: "email" as const,
+    label: "이메일 주소 (EMAIL ADDRESS)",
+    placeholder: "curator@stylesync.com",
+    autoComplete: "email",
+  },
+  {
+    id: "nickname",
+    name: "nickname",
+    type: "text" as const,
+    label: "닉네임 (NICKNAME)",
+    placeholder: "@username",
+    autoComplete: "nickname",
+  },
+  {
+    id: "password",
+    name: "password",
+    type: "password" as const,
+    label: "비밀번호 (PASSWORD)",
+    placeholder: "••••••••",
+    autoComplete: "new-password",
+  },
+  {
+    id: "confirmPassword",
+    name: "confirmPassword",
+    type: "password" as const,
+    label: "비밀번호 확인 (CONFIRM PASSWORD)",
+    placeholder: "••••••••",
+    autoComplete: "new-password",
+  },
+];
+
 export default function SignupPage() {
-  return <div>회원가입</div>;
+  return (
+    <main className="page-container section-wrapper">
+      <AuthSplitLayout
+        entryTitle="회원가입"
+        entryDescription="당신의 비전을 위한 공간입니다."
+        submitLabel="가입하기"
+        footerLabel="이미 계정이 있으신가요?"
+        footerHref="/login"
+        footerLinkText="로그인"
+        fields={signupFields}
+        leadEyebrow="STYLESYNC"
+        leadTitle={
+          <>
+            SYNC YOUR
+            <br />
+            <span className="text-primary-container">AESTHETIC</span>
+          </>
+        }
+        leadHeadline="당신의 감각을 연결하세요"
+        leadDescription={
+          <>
+            음악, 영화, 패션을 아우르는 개인 맞춤형
+            <br />
+            스타일 큐레이션 솔루션
+          </>
+        }
+        leadMeta={
+          <div className="flex items-center gap-4">
+            <span className="rounded-none border border-on-background px-4 py-2 type-title-sm text-on-background">
+              SYNCING
+            </span>
+            <span className="type-title-sm text-[#b7b1a9]">THE VISIONARY CURATOR</span>
+          </div>
+        }
+        leadVisual={
+          <div className="signup-card-shadow flex h-[190px] w-[320px] items-center justify-center gap-10 rounded-[2.75rem] bg-surface">
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-white shadow-[0_8px_20px_rgba(26,28,26,0.12)]">
+              <div className="h-10 w-10 rounded-full bg-primary-container" />
+            </div>
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-white shadow-[0_8px_20px_rgba(26,28,26,0.12)]">
+              <div className="h-10 w-10 rounded-full bg-primary-container" />
+            </div>
+          </div>
+        }
+      />
+    </main>
+  );
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -38,6 +38,7 @@ const signupFields = [
 export default function SignupPage() {
   return (
     <main className="page-container section-wrapper">
+      {/* TODO(FT-006-1): Add required terms/privacy consent and optional marketing consent after the design is finalized. */}
       <AuthSplitLayout
         entryTitle="회원가입"
         entryDescription="당신의 비전을 위한 공간입니다."

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -38,7 +38,7 @@ const signupFields = [
 export default function SignupPage() {
   return (
     <main className="page-container section-wrapper">
-      {/* TODO(FT-006-1): Add required terms/privacy consent and optional marketing consent after the design is finalized. */}
+      {/* TODO(FT-006-1): 디자인이 보강되면 이용약관/개인정보 필수 동의와 마케팅 선택 동의 UI를 추가한다. */}
       <AuthSplitLayout
         entryTitle="회원가입"
         entryDescription="당신의 비전을 위한 공간입니다."

--- a/src/components/auth/authEntrySection/AuthEntrySection.tsx
+++ b/src/components/auth/authEntrySection/AuthEntrySection.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import type { IAuthEntrySectionProps } from "./authEntrySection.types";
+
+export const AuthEntrySection = ({
+  title,
+  description,
+  submitLabel,
+  footerLabel,
+  footerHref,
+  footerLinkText,
+  fields,
+}: IAuthEntrySectionProps) => {
+  return (
+    <section className="flex w-full flex-col items-center">
+      <h2 className="heading-section keep-all">{title}</h2>
+      <p className="mt-4 type-title-lg text-on-surface-variant">{description}</p>
+
+      <section className="signup-card-shadow mt-8 w-full max-w-[32rem] rounded-[2.5rem] bg-surface px-8 py-8 md:px-12 md:py-12">
+        <h3 className="sr-only">{title} 입력 폼</h3>
+        <form className="space-y-6">
+          {fields.map((field) => (
+            <Input key={field.id ?? field.name} {...field} />
+          ))}
+          <Button fullWidth size="md" className="mt-2 h-[62px] text-title-lg">
+            {submitLabel}
+          </Button>
+        </form>
+      </section>
+
+      <div className="mt-8 flex items-center gap-2">
+        <span className="type-title-sm text-on-background">{footerLabel}</span>
+        <Link href={footerHref} className="type-title-sm text-on-background">
+          {footerLinkText}
+        </Link>
+      </div>
+
+      <Link
+        href="#"
+        className="mt-6 inline-flex items-center gap-2 type-label-md-regular text-on-background"
+      >
+        비회원으로 계속하기
+      </Link>
+    </section>
+  );
+};

--- a/src/components/auth/authEntrySection/AuthEntrySection.tsx
+++ b/src/components/auth/authEntrySection/AuthEntrySection.tsx
@@ -39,7 +39,7 @@ export const AuthEntrySection = ({
       </div>
 
       <Link
-        href="#"
+        href="/"
         className="mt-6 inline-flex items-center gap-2 type-label-md-regular text-on-background"
       >
         비회원으로 계속하기

--- a/src/components/auth/authEntrySection/authEntrySection.types.ts
+++ b/src/components/auth/authEntrySection/authEntrySection.types.ts
@@ -1,0 +1,16 @@
+import type { IInputProps } from "@/components/ui/input";
+
+export type IAuthEntryField = Pick<
+  IInputProps,
+  "autoComplete" | "helperText" | "id" | "label" | "name" | "placeholder" | "type"
+>;
+
+export interface IAuthEntrySectionProps {
+  title: string;
+  description: string;
+  submitLabel: string;
+  footerLabel: string;
+  footerHref: string;
+  footerLinkText: string;
+  fields: IAuthEntryField[];
+}

--- a/src/components/auth/authEntrySection/index.ts
+++ b/src/components/auth/authEntrySection/index.ts
@@ -1,0 +1,2 @@
+export { AuthEntrySection } from "./AuthEntrySection";
+export type { IAuthEntryField, IAuthEntrySectionProps } from "./authEntrySection.types";

--- a/src/components/auth/authForm/AuthForm.tsx
+++ b/src/components/auth/authForm/AuthForm.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+import type { IAuthFormProps } from "./authForm.types";
+
+export const AuthForm = ({
+  badgeLabel,
+  title,
+  description,
+  submitLabel,
+  footerLabel,
+  footerHref,
+  footerLinkText,
+  fields,
+}: IAuthFormProps) => {
+  return (
+    <section
+      className="signup-card-shadow mx-auto w-full max-w-[31.5rem] rounded-[2rem] border border-outline-variant bg-surface"
+      aria-labelledby="auth-form-title"
+    >
+      <div className="px-8 py-8 md:px-12 md:py-10">
+        <p className="type-label-md-regular text-on-surface-variant">{badgeLabel}</p>
+
+        <div className="mt-4 space-y-3">
+          <h2
+            id="auth-form-title"
+            className="type-headline-sm text-on-background md:type-headline-md"
+          >
+            {title}
+          </h2>
+          <p className="type-body-sm keep-all text-on-surface-variant md:type-body-md">
+            {description}
+          </p>
+        </div>
+
+        <form className="mt-8 space-y-5">
+          {fields.map((field) => (
+            <Input key={field.id ?? field.name} {...field} />
+          ))}
+
+          <Button type="submit" fullWidth size="md" className="mt-3">
+            {submitLabel}
+          </Button>
+        </form>
+
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-2 border-t border-outline-variant pt-5 text-center">
+          <span className="type-label-md-regular text-on-surface-variant">{footerLabel}</span>
+          <Link
+            href={footerHref}
+            className="type-label-md-regular text-primary-container transition-opacity hover:opacity-70"
+          >
+            {footerLinkText}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/auth/authForm/authForm.types.ts
+++ b/src/components/auth/authForm/authForm.types.ts
@@ -1,0 +1,17 @@
+import type { IInputProps } from "@/components/ui/input";
+
+export type IAuthFormField = Pick<
+  IInputProps,
+  "autoComplete" | "helperText" | "id" | "label" | "name" | "placeholder" | "type"
+>;
+
+export interface IAuthFormProps {
+  badgeLabel: string;
+  title: string;
+  description: string;
+  submitLabel: string;
+  footerLabel: string;
+  footerHref: string;
+  footerLinkText: string;
+  fields: IAuthFormField[];
+}

--- a/src/components/auth/authForm/index.ts
+++ b/src/components/auth/authForm/index.ts
@@ -1,0 +1,2 @@
+export { AuthForm } from "./AuthForm";
+export type { IAuthFormField, IAuthFormProps } from "./authForm.types";

--- a/src/components/auth/authLanding/AuthLanding.tsx
+++ b/src/components/auth/authLanding/AuthLanding.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+
+import { AuthSplitLayout } from "@/components/auth/authSplitLayout";
+
+import { LoginLandingContent } from "./LoginLandingContent";
+
+const loginFields = [
+  {
+    id: "email",
+    name: "email",
+    type: "email" as const,
+    label: "이메일",
+    placeholder: "name@example.com",
+    autoComplete: "email",
+  },
+  {
+    id: "password",
+    name: "password",
+    type: "password" as const,
+    label: "비밀번호",
+    placeholder: "비밀번호를 입력해 주세요",
+    autoComplete: "current-password",
+  },
+];
+
+export const AuthLanding = () => {
+  const [isEmailFormOpen, setIsEmailFormOpen] = useState(false);
+
+  return (
+    <section className="page-container section-wrapper">
+      {isEmailFormOpen ? (
+        <AuthSplitLayout
+          entryTitle="이메일로 로그인"
+          entryDescription="StyleSync의 다양한 취향 결과와 기록을 다시 확인해 보세요"
+          submitLabel="로그인"
+          footerLabel="아직 계정이 없으신가요?"
+          footerHref="/signup"
+          footerLinkText="회원가입"
+          fields={loginFields}
+          leadEyebrow="STYLESYNC"
+          leadTitle={
+            <>
+              SYNC YOUR
+              <br />
+              <span className="text-primary-container">AESTHETIC</span>
+            </>
+          }
+          leadHeadline="당신의 감각과 연결하세요"
+          leadDescription={
+            <>
+              음악, 영화, 패션을 아우르는 개인 맞춤형
+              <br />
+              스타일 큐레이션 여정으로
+            </>
+          }
+          leadMeta={
+            <div className="flex items-center gap-4">
+              <span className="rounded-none border border-on-background px-4 py-2 type-title-sm text-on-background">
+                SYNCING
+              </span>
+              <span className="type-title-sm text-on-surface-variant">THE VISIONARY CURATOR</span>
+            </div>
+          }
+          leadVisual={
+            <div className="signup-card-shadow flex h-[190px] w-[320px] items-center justify-center gap-10 rounded-[2.75rem] bg-surface">
+              <div className="profile-card-shadow flex h-20 w-20 items-center justify-center rounded-full bg-surface">
+                <div className="h-10 w-10 rounded-full bg-primary-container" />
+              </div>
+              <div className="profile-card-shadow flex h-20 w-20 items-center justify-center rounded-full bg-surface">
+                <div className="h-10 w-10 rounded-full bg-primary-container" />
+              </div>
+            </div>
+          }
+        />
+      ) : (
+        <LoginLandingContent onOpenEmail={() => setIsEmailFormOpen(true)} />
+      )}
+    </section>
+  );
+};

--- a/src/components/auth/authLanding/LoginLandingContent.tsx
+++ b/src/components/auth/authLanding/LoginLandingContent.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import Icon from "@/components/ui/Icon/Icon";
+
+const LoginCard = ({
+  className,
+  title,
+  backgroundClassName,
+  accentClassName,
+  titleClassName,
+}: {
+  className: string;
+  title: string;
+  backgroundClassName: string;
+  accentClassName?: string;
+  titleClassName?: string;
+}) => {
+  return (
+    <div className={className}>
+      <div
+        className={`relative flex h-full w-full flex-col items-center justify-between overflow-hidden rounded-[3rem] p-8 ${backgroundClassName}`}
+      >
+        <div className="flex h-24 w-24 items-center justify-center rounded-full bg-white shadow-[0_10px_30px_rgba(26,28,26,0.08)]">
+          <div className="relative h-16 w-16 rounded-full bg-white">
+            <span
+              className={`absolute left-[12px] top-[26px] h-3 w-3 rounded-full bg-[#2e2e2e] ${accentClassName ?? ""}`}
+            />
+            <span
+              className={`absolute right-[12px] top-[26px] h-3 w-3 rounded-full bg-[#2e2e2e] ${accentClassName ?? ""}`}
+            />
+            <span className="absolute left-1/2 top-[44px] h-px w-7 -translate-x-1/2 rotate-[-8deg] bg-[#d4d4d4]" />
+          </div>
+        </div>
+        <p
+          className={`whitespace-pre-line text-center font-headline text-[1.15rem] font-black leading-[1.05] tracking-[-0.05em] ${titleClassName ?? "text-white"}`}
+        >
+          {title}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export const LoginLandingContent = ({ onOpenEmail }: { onOpenEmail: () => void }) => {
+  return (
+    <section className="header-gap relative min-h-[640px] lg:mt-0 lg:min-h-[780px]">
+      <h2 className="sr-only">로그인</h2>
+
+      <LoginCard
+        className="absolute left-[4%] top-[2%] hidden h-[323px] w-[243px] -rotate-[15deg] lg:block"
+        title={"Neo-Tokyo\nHacker"}
+        backgroundClassName="bg-[linear-gradient(180deg,#1d1f1d_0%,#202221_38%,#d9d6d1_100%)]"
+      />
+      <LoginCard
+        className="absolute left-[8%] top-[56%] hidden h-[282px] w-[206px] -rotate-[12deg] lg:block"
+        title={"Forest Folk\nDreamer"}
+        backgroundClassName="bg-[linear-gradient(180deg,#d9eef0_0%,#d9eef0_100%)]"
+        accentClassName="bg-[#41c86b]"
+        titleClassName="text-on-background"
+      />
+      <LoginCard
+        className="absolute right-[2%] top-[6%] hidden h-[352px] w-[256px] rotate-[18deg] lg:block"
+        title={"Retro Future\nPilot"}
+        backgroundClassName="bg-[linear-gradient(180deg,#ff6408_0%,#ff6508_46%,#f0dfd0_100%)]"
+      />
+      <LoginCard
+        className="absolute right-[2%] top-[52%] hidden h-[352px] w-[287px] -rotate-[12deg] lg:block"
+        title={"MIDNIGHT JAZZ\nPOET"}
+        backgroundClassName="bg-[#0b355d]"
+        titleClassName="text-[#c8d8ff]"
+      />
+
+      <div className="mx-auto flex w-full max-w-[560px] flex-col items-center text-center lg:max-w-[460px]">
+        <h3 className="heading-display">StyleSync</h3>
+        <div className="mt-6 h-1.5 w-12 rounded-full bg-primary-container lg:mt-7" />
+        <p className="mt-8 heading-section keep-all">나만의 스타일을 찾아보세요</p>
+        <p className="mt-4 type-title-md text-on-surface-variant">
+          당신의 감각을 완성하는 큐레이션의 시작
+        </p>
+
+        <section className="signup-card-shadow mt-10 w-full rounded-[2.5rem] bg-surface px-6 py-10 md:px-10 lg:mt-12">
+          <h4 className="sr-only">로그인 시작 옵션</h4>
+          <Button
+            fullWidth
+            size="md"
+            className="h-[58px] text-title-md md:h-[60px]"
+            icon={<Icon name="google" size={24} className="text-primary-foreground" />}
+            iconPosition="left"
+          >
+            Google로 시작하기
+          </Button>
+          <p className="mt-10 type-label-md-regular text-on-surface-variant">또는</p>
+          <Button
+            type="button"
+            onClick={onOpenEmail}
+            variant="ghost"
+            size="md"
+            className="mt-10 h-auto p-0 text-title-md text-on-background hover:opacity-70"
+          >
+            이메일로 시작하기
+          </Button>
+        </section>
+
+        <div className="mt-10 flex items-center justify-center gap-2">
+          <span className="type-title-sm text-on-surface-variant">계정이 없으신가요?</span>
+          <Link href="/signup" className="type-title-sm text-primary-container">
+            회원가입
+          </Link>
+        </div>
+
+        <Link
+          href="#"
+          className="mt-5 inline-flex items-center gap-2 type-label-md-regular text-on-background"
+        >
+          비회원으로 계속하기
+          <Icon name="arrowRight" size={18} className="text-on-background" />
+        </Link>
+      </div>
+    </section>
+  );
+};

--- a/src/components/auth/authLanding/LoginLandingContent.tsx
+++ b/src/components/auth/authLanding/LoginLandingContent.tsx
@@ -112,7 +112,7 @@ export const LoginLandingContent = ({ onOpenEmail }: { onOpenEmail: () => void }
         </div>
 
         <Link
-          href="#"
+          href="/"
           className="mt-5 inline-flex items-center gap-2 type-label-md-regular text-on-background"
         >
           비회원으로 계속하기

--- a/src/components/auth/authSplitLayout/AuthSplitLayout.tsx
+++ b/src/components/auth/authSplitLayout/AuthSplitLayout.tsx
@@ -1,0 +1,60 @@
+import { AuthEntrySection } from "@/components/auth/authEntrySection";
+
+import type { IAuthSplitLayoutProps } from "./authSplitLayout.types";
+
+export const AuthSplitLayout = ({
+  entryTitle,
+  entryDescription,
+  submitLabel,
+  footerLabel,
+  footerHref,
+  footerLinkText,
+  fields,
+  leadEyebrow,
+  leadTitle,
+  leadHeadline,
+  leadDescription,
+  leadMeta,
+  leadVisual,
+}: IAuthSplitLayoutProps) => {
+  return (
+    <section className="grid grid-cols-1 items-start gap-12 lg:mt-0 lg:grid-cols-[1fr_512px] lg:items-center lg:justify-between lg:gap-20">
+      <section className="hidden text-center lg:flex flex-col items-center">
+        {leadEyebrow ? <p className="type-headline-sm text-[#d4d0ca]">{leadEyebrow}</p> : null}
+
+        {leadTitle ? (
+          <div className="font-headline text-[5.6rem] font-black leading-[0.92] tracking-[-0.06em] text-on-background">
+            {leadTitle}
+          </div>
+        ) : null}
+
+        {leadHeadline ? (
+          <p className="mt-10 text-[2.2rem] font-bold tracking-[-0.05em] text-on-background">
+            {leadHeadline}
+          </p>
+        ) : null}
+
+        {leadDescription ? (
+          <div className="mt-4 max-w-[22rem] type-title-sm text-on-surface-variant">
+            {leadDescription}
+          </div>
+        ) : null}
+
+        {leadMeta ? <div className="mt-8">{leadMeta}</div> : null}
+        {leadVisual ? <div className="mt-20">{leadVisual}</div> : null}
+      </section>
+
+      <section className="mx-auto flex w-full max-w-[32rem] flex-col items-center text-center lg:mx-0 lg:max-w-none">
+        <AuthEntrySection
+          title={entryTitle}
+          description={entryDescription}
+          submitLabel={submitLabel}
+          footerLabel={footerLabel}
+          footerHref={footerHref}
+          footerLinkText={footerLinkText}
+          fields={fields}
+        />
+      </section>
+    </section>
+  );
+};

--- a/src/components/auth/authSplitLayout/authSplitLayout.types.ts
+++ b/src/components/auth/authSplitLayout/authSplitLayout.types.ts
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+import type { IAuthEntryField } from "@/components/auth/authEntrySection";
+
+export interface IAuthSplitLayoutProps {
+  entryTitle: string;
+  entryDescription: string;
+  submitLabel: string;
+  footerLabel: string;
+  footerHref: string;
+  footerLinkText: string;
+  fields: IAuthEntryField[];
+  leadEyebrow?: string;
+  leadTitle?: ReactNode;
+  leadHeadline?: string;
+  leadDescription?: ReactNode;
+  leadMeta?: ReactNode;
+  leadVisual?: ReactNode;
+}

--- a/src/components/auth/authSplitLayout/index.ts
+++ b/src/components/auth/authSplitLayout/index.ts
@@ -1,0 +1,2 @@
+export { AuthSplitLayout } from "./AuthSplitLayout";
+export type { IAuthSplitLayoutProps } from "./authSplitLayout.types";

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -29,7 +29,10 @@ export const Input = forwardRef<HTMLInputElement, IInputProps>(
     return (
       <div className={cn("flex w-full flex-col gap-2", className)}>
         {label ? (
-          <label htmlFor={id} className="type-label-xs md:type-label-md text-on-surface-variant">
+          <label
+            htmlFor={id}
+            className="w-full text-start type-label-xs md:type-label-md text-on-surface-variant"
+          >
             {label}
           </label>
         ) : null}


### PR DESCRIPTION
## PR 제목

feat / SS-99-AuthFormUI - 로그인 랜딩 및 인증 폼 UI 구성

## PR 본문

### 반영 브랜치

SS-99-AuthFormUI -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

- 로그인 페이지의 랜딩 화면과 이메일 로그인 전환 흐름을 AuthLanding으로 분리
- 공통으로 사용할 수 있도록 AuthSplitLayout, AuthEntrySection, AuthForm 컴포넌트를 구성
- 파일 흐름은 page.tsx -> AuthLanding -> LoginLandingContent / AuthSplitLayout -> AuthEntrySection 구조로 정리

Closes #99

### 테스트 결과 (선택)

### 스크린샷 (선택)

### 리뷰 요구사항(선택)


