### PR TITLE
feat / SS-100-AuthSessionStore - 인증 세션 스토어 구현

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,4 +1,11 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { useRouter } from "next/navigation";
+
 import { AuthSplitLayout } from "@/components/auth/authSplitLayout";
+import { useAuthSessionStore } from "@/store/authSessionStore";
 
 const signupFields = [
   {
@@ -36,6 +43,52 @@ const signupFields = [
 ];
 
 export default function SignupPage() {
+  const router = useRouter();
+  const signUpWithPassword = useAuthSessionStore((state) => state.signUpWithPassword);
+  const isSubmitting = useAuthSessionStore((state) => state.isLoading);
+  const errorMessage = useAuthSessionStore((state) => state.errorMessage);
+  const errorField = useAuthSessionStore((state) => state.errorField);
+  const statusMessage = useAuthSessionStore((state) => state.statusMessage);
+  const setError = useAuthSessionStore((state) => state.setError);
+  const [localFieldErrors, setLocalFieldErrors] = useState<Partial<Record<string, string>>>({});
+
+  const fieldErrors = useMemo(() => {
+    const nextFieldErrors = { ...localFieldErrors };
+
+    if (errorField && errorMessage) {
+      nextFieldErrors[errorField] = errorMessage;
+    }
+
+    return Object.keys(nextFieldErrors).length > 0 ? nextFieldErrors : undefined;
+  }, [errorField, errorMessage, localFieldErrors]);
+
+  const handleSignup = async (formData: FormData) => {
+    setLocalFieldErrors({});
+
+    const email = String(formData.get("email") ?? "").trim();
+    const nickname = String(formData.get("nickname") ?? "").trim();
+    const password = String(formData.get("password") ?? "");
+    const confirmPassword = String(formData.get("confirmPassword") ?? "");
+
+    if (password !== confirmPassword) {
+      setError({ message: null });
+      setLocalFieldErrors({
+        confirmPassword: "비밀번호가 일치하지 않아요.",
+      });
+      return;
+    }
+
+    const isSuccess = await signUpWithPassword({
+      email,
+      password,
+      nickname,
+    });
+
+    if (isSuccess) {
+      router.refresh();
+    }
+  };
+
   return (
     <main className="page-container section-wrapper">
       {/* TODO(FT-006-1): 디자인이 보강되면 이용약관/개인정보 필수 동의와 마케팅 선택 동의 UI를 추가한다. */}
@@ -47,6 +100,11 @@ export default function SignupPage() {
         footerHref="/login"
         footerLinkText="로그인"
         fields={signupFields}
+        onSubmit={handleSignup}
+        isSubmitting={isSubmitting}
+        errorMessage={errorMessage}
+        statusMessage={statusMessage}
+        fieldErrors={fieldErrors}
         leadEyebrow="STYLESYNC"
         leadTitle={
           <>
@@ -68,15 +126,15 @@ export default function SignupPage() {
             <span className="rounded-none border border-on-background px-4 py-2 type-title-sm text-on-background">
               SYNCING
             </span>
-            <span className="type-title-sm text-[#b7b1a9]">THE VISIONARY CURATOR</span>
+            <span className="type-title-sm text-on-surface-variant">THE VISIONARY CURATOR</span>
           </div>
         }
         leadVisual={
           <div className="signup-card-shadow flex h-[190px] w-[320px] items-center justify-center gap-10 rounded-[2.75rem] bg-surface">
-            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-white shadow-[0_8px_20px_rgba(26,28,26,0.12)]">
+            <div className="profile-card-shadow flex h-20 w-20 items-center justify-center rounded-full bg-surface">
               <div className="h-10 w-10 rounded-full bg-primary-container" />
             </div>
-            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-white shadow-[0_8px_20px_rgba(26,28,26,0.12)]">
+            <div className="profile-card-shadow flex h-20 w-20 items-center justify-center rounded-full bg-surface">
               <div className="h-10 w-10 rounded-full bg-primary-container" />
             </div>
           </div>

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  if (code) {
+    const supabase = await createSupabaseServerClient();
+    await supabase.auth.exchangeCodeForSession(code);
+  }
+
+  return NextResponse.redirect(new URL(next, origin));
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Epilogue, Plus_Jakarta_Sans, Noto_Sans_KR, JetBrains_Mono } from "next/font/google";
 
+import { AuthSessionSync } from "@/components/auth/AuthSessionSync";
 import { Footer } from "@/components/layout/footer";
 import { Header } from "@/components/layout/header";
 import "@/styles/globals.css";
@@ -55,6 +56,7 @@ export default function RootLayout({
       className={`${epilogue.variable} ${plusJakartaSans.variable} ${notoSansKR.variable} ${jetbrainsMono.variable}`}
     >
       <body className="antialiased flex min-h-screen flex-col">
+        <AuthSessionSync />
         <Header />
         <main className="flex-1">{children}</main>
         <Footer />

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,11 +1,46 @@
-/**
- * 설정 페이지 — /settings
- * TODO: 설정 UI 구현
- */
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { useAuthSessionStore } from "@/store/authSessionStore";
+
 export default function SettingsPage() {
+  const router = useRouter();
+  const signOut = useAuthSessionStore((state) => state.signOut);
+  const isSubmitting = useAuthSessionStore((state) => state.isLoading);
+  const errorMessage = useAuthSessionStore((state) => state.errorMessage);
+
+  const handleSignOut = async () => {
+    await signOut();
+    router.replace("/");
+    router.refresh();
+  };
+
   return (
-    <div className="flex min-h-screen items-center justify-center">
-      <p className="text-on-background font-body">설정 페이지 준비 중</p>
+    <div className="page-container section-wrapper">
+      <div className="mx-auto flex w-full max-w-[32rem] flex-col items-center rounded-[2rem] bg-surface px-8 py-10 text-center signup-card-shadow">
+        <h1 className="heading-section">설정</h1>
+        <p className="mt-4 type-title-md text-on-surface-variant">
+          현재는 로그아웃 기능을 먼저 제공합니다.
+        </p>
+
+        {errorMessage ? (
+          <p className="mt-6 type-label-md-regular text-destructive" role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <Button
+          type="button"
+          size="md"
+          className="mt-8 w-full max-w-[16rem]"
+          onClick={handleSignOut}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "처리 중..." : "로그아웃"}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/auth/AuthSessionSync.tsx
+++ b/src/components/auth/AuthSessionSync.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { createClient } from "@/lib/supabase/client";
+import { useAuthSessionStore } from "@/store/authSessionStore";
+
+export const AuthSessionSync = () => {
+  const initialize = useAuthSessionStore((state) => state.initialize);
+  const setSession = useAuthSessionStore((state) => state.setSession);
+  const setInitialized = useAuthSessionStore((state) => state.setInitialized);
+  const setLoading = useAuthSessionStore((state) => state.setLoading);
+  const setErrorMessage = useAuthSessionStore((state) => state.setErrorMessage);
+
+  useEffect(() => {
+    const supabase = createClient();
+    let isMounted = true;
+
+    const syncInitialSession = async () => {
+      setLoading(true);
+
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+
+      if (!isMounted) {
+        return;
+      }
+
+      if (error) {
+        setErrorMessage(error.message);
+        setInitialized(true);
+        setLoading(false);
+        return;
+      }
+
+      initialize(session);
+    };
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+      setInitialized(true);
+    });
+
+    void syncInitialSession();
+
+    return () => {
+      isMounted = false;
+      subscription.unsubscribe();
+    };
+  }, [initialize, setErrorMessage, setInitialized, setLoading, setSession]);
+
+  return null;
+};

--- a/src/components/auth/authEntrySection/AuthEntrySection.tsx
+++ b/src/components/auth/authEntrySection/AuthEntrySection.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
@@ -13,7 +15,22 @@ export const AuthEntrySection = ({
   footerHref,
   footerLinkText,
   fields,
+  onSubmit,
+  isSubmitting = false,
+  errorMessage,
+  statusMessage,
+  fieldErrors,
 }: IAuthEntrySectionProps) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!onSubmit) {
+      return;
+    }
+
+    await onSubmit(new FormData(event.currentTarget));
+  };
+
   return (
     <section className="flex w-full flex-col items-center">
       <h2 className="heading-section keep-all">{title}</h2>
@@ -21,12 +38,39 @@ export const AuthEntrySection = ({
 
       <section className="signup-card-shadow mt-8 w-full max-w-[32rem] rounded-[2.5rem] bg-surface px-8 py-8 md:px-12 md:py-12">
         <h3 className="sr-only">{title} 입력 폼</h3>
-        <form className="space-y-6">
-          {fields.map((field) => (
-            <Input key={field.id ?? field.name} {...field} />
-          ))}
-          <Button fullWidth size="md" className="mt-2 h-[62px] text-title-lg">
-            {submitLabel}
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          {fields.map((field) => {
+            const fieldKey = field.name ?? field.id ?? "";
+            const fieldError = fieldErrors?.[fieldKey];
+
+            return (
+              <Input
+                key={field.id ?? field.name}
+                {...field}
+                variant={fieldError ? "error" : "default"}
+                helperText={fieldError ?? field.helperText}
+              />
+            );
+          })}
+
+          {errorMessage && (!fieldErrors || Object.keys(fieldErrors).length === 0) ? (
+            <p className="type-label-md-regular text-destructive" role="alert">
+              {errorMessage}
+            </p>
+          ) : null}
+
+          {statusMessage ? (
+            <p className="type-label-md-regular text-on-surface-variant">{statusMessage}</p>
+          ) : null}
+
+          <Button
+            fullWidth
+            size="md"
+            className="mt-2 h-[62px] text-title-lg"
+            type="submit"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "처리 중..." : submitLabel}
           </Button>
         </form>
       </section>

--- a/src/components/auth/authEntrySection/authEntrySection.types.ts
+++ b/src/components/auth/authEntrySection/authEntrySection.types.ts
@@ -13,4 +13,9 @@ export interface IAuthEntrySectionProps {
   footerHref: string;
   footerLinkText: string;
   fields: IAuthEntryField[];
+  onSubmit?: (formData: FormData) => void | Promise<void>;
+  isSubmitting?: boolean;
+  errorMessage?: string | null;
+  statusMessage?: string | null;
+  fieldErrors?: Partial<Record<string, string>>;
 }

--- a/src/components/auth/authLanding/AuthLanding.tsx
+++ b/src/components/auth/authLanding/AuthLanding.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from "react";
 
+import { useRouter } from "next/navigation";
+
 import { AuthSplitLayout } from "@/components/auth/authSplitLayout";
+import { useAuthSessionStore } from "@/store/authSessionStore";
 
 import { LoginLandingContent } from "./LoginLandingContent";
 
@@ -26,7 +29,29 @@ const loginFields = [
 ];
 
 export const AuthLanding = () => {
+  const router = useRouter();
   const [isEmailFormOpen, setIsEmailFormOpen] = useState(false);
+  const signInWithGoogle = useAuthSessionStore((state) => state.signInWithGoogle);
+  const signInWithPassword = useAuthSessionStore((state) => state.signInWithPassword);
+  const isSubmitting = useAuthSessionStore((state) => state.isLoading);
+  const errorMessage = useAuthSessionStore((state) => state.errorMessage);
+  const errorField = useAuthSessionStore((state) => state.errorField);
+
+  const handleGoogleLogin = async () => {
+    await signInWithGoogle();
+  };
+
+  const handleEmailLogin = async (formData: FormData) => {
+    const email = String(formData.get("email") ?? "").trim();
+    const password = String(formData.get("password") ?? "");
+
+    const isSuccess = await signInWithPassword(email, password);
+
+    if (isSuccess) {
+      router.replace("/");
+      router.refresh();
+    }
+  };
 
   return (
     <section className="page-container section-wrapper">
@@ -39,6 +64,10 @@ export const AuthLanding = () => {
           footerHref="/signup"
           footerLinkText="회원가입"
           fields={loginFields}
+          onSubmit={handleEmailLogin}
+          isSubmitting={isSubmitting}
+          errorMessage={errorMessage}
+          fieldErrors={errorField && errorMessage ? { [errorField]: errorMessage } : undefined}
           leadEyebrow="STYLESYNC"
           leadTitle={
             <>
@@ -75,7 +104,12 @@ export const AuthLanding = () => {
           }
         />
       ) : (
-        <LoginLandingContent onOpenEmail={() => setIsEmailFormOpen(true)} />
+        <LoginLandingContent
+          onOpenEmail={() => setIsEmailFormOpen(true)}
+          onSignInWithGoogle={handleGoogleLogin}
+          isSubmitting={isSubmitting}
+          errorMessage={errorMessage}
+        />
       )}
     </section>
   );

--- a/src/components/auth/authLanding/LoginLandingContent.tsx
+++ b/src/components/auth/authLanding/LoginLandingContent.tsx
@@ -44,7 +44,19 @@ const LoginCard = ({
   );
 };
 
-export const LoginLandingContent = ({ onOpenEmail }: { onOpenEmail: () => void }) => {
+type LoginLandingContentProps = {
+  onOpenEmail: () => void;
+  onSignInWithGoogle: () => void | Promise<void>;
+  isSubmitting?: boolean;
+  errorMessage?: string | null;
+};
+
+export const LoginLandingContent = ({
+  onOpenEmail,
+  onSignInWithGoogle,
+  isSubmitting = false,
+  errorMessage,
+}: LoginLandingContentProps) => {
   return (
     <section className="header-gap relative min-h-[640px] lg:mt-0 lg:min-h-[780px]">
       <h2 className="sr-only">로그인</h2>
@@ -86,12 +98,22 @@ export const LoginLandingContent = ({ onOpenEmail }: { onOpenEmail: () => void }
           <Button
             fullWidth
             size="md"
+            type="button"
+            disabled={isSubmitting}
+            onClick={onSignInWithGoogle}
             className="h-[58px] text-title-md md:h-[60px]"
             icon={<Icon name="google" size={24} className="text-primary-foreground" />}
             iconPosition="left"
           >
-            Google로 시작하기
+            {isSubmitting ? "처리 중..." : "Google로 시작하기"}
           </Button>
+
+          {errorMessage ? (
+            <p className="mt-6 type-label-md-regular text-destructive" role="alert">
+              {errorMessage}
+            </p>
+          ) : null}
+
           <p className="mt-10 type-label-md-regular text-on-surface-variant">또는</p>
           <Button
             type="button"

--- a/src/components/auth/authSplitLayout/AuthSplitLayout.tsx
+++ b/src/components/auth/authSplitLayout/AuthSplitLayout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { AuthEntrySection } from "@/components/auth/authEntrySection";
 
 import type { IAuthSplitLayoutProps } from "./authSplitLayout.types";
@@ -10,6 +12,11 @@ export const AuthSplitLayout = ({
   footerHref,
   footerLinkText,
   fields,
+  onSubmit,
+  isSubmitting,
+  errorMessage,
+  statusMessage,
+  fieldErrors,
   leadEyebrow,
   leadTitle,
   leadHeadline,
@@ -19,8 +26,10 @@ export const AuthSplitLayout = ({
 }: IAuthSplitLayoutProps) => {
   return (
     <section className="grid grid-cols-1 items-start gap-12 lg:mt-0 lg:grid-cols-[1fr_512px] lg:items-center lg:justify-between lg:gap-20">
-      <section className="hidden text-center lg:flex flex-col items-center">
-        {leadEyebrow ? <p className="type-headline-sm text-[#d4d0ca]">{leadEyebrow}</p> : null}
+      <section className="hidden lg:flex flex-col items-center text-center">
+        {leadEyebrow ? (
+          <p className="type-headline-sm text-on-surface-variant">{leadEyebrow}</p>
+        ) : null}
 
         {leadTitle ? (
           <div className="font-headline text-[5.6rem] font-black leading-[0.92] tracking-[-0.06em] text-on-background">
@@ -53,6 +62,11 @@ export const AuthSplitLayout = ({
           footerHref={footerHref}
           footerLinkText={footerLinkText}
           fields={fields}
+          onSubmit={onSubmit}
+          isSubmitting={isSubmitting}
+          errorMessage={errorMessage}
+          statusMessage={statusMessage}
+          fieldErrors={fieldErrors}
         />
       </section>
     </section>

--- a/src/components/auth/authSplitLayout/authSplitLayout.types.ts
+++ b/src/components/auth/authSplitLayout/authSplitLayout.types.ts
@@ -10,6 +10,11 @@ export interface IAuthSplitLayoutProps {
   footerHref: string;
   footerLinkText: string;
   fields: IAuthEntryField[];
+  onSubmit?: (formData: FormData) => void | Promise<void>;
+  isSubmitting?: boolean;
+  errorMessage?: string | null;
+  statusMessage?: string | null;
+  fieldErrors?: Partial<Record<string, string>>;
   leadEyebrow?: string;
   leadTitle?: ReactNode;
   leadHeadline?: string;

--- a/src/components/layout/header/Header.tsx
+++ b/src/components/layout/header/Header.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 
 import { Icon } from "@/components/ui/Icon";
+import { useAuthSessionStore } from "@/store/authSessionStore";
 
 import type { IHeaderProps } from "./header.types";
 
@@ -17,13 +18,15 @@ import type { IHeaderProps } from "./header.types";
  * ├─────────────────────────────────────────────────────────────┤
  * │  로그인 후                                                   │
  * │  전 브레이크포인트: 로고 + 유저 아이콘 + 설정 아이콘          │
- * │  TODO: #100 auth session store 연결 후 isLoggedIn 제거       │
  * └─────────────────────────────────────────────────────────────┘
  *
  * @container 기반 반응형: md(768px), lg(1280px)
  * 배경: rgba(250,249,246,0.8) + blur(24px) / 높이: 80px (전 구간 동일)
  */
-export const Header = ({ isLoggedIn = false }: IHeaderProps) => {
+export const Header = ({ isLoggedIn: isLoggedInProp }: IHeaderProps) => {
+  const isAuthenticated = useAuthSessionStore((state) => state.isAuthenticated);
+  const isLoggedIn = isLoggedInProp ?? isAuthenticated;
+
   return (
     <header className="sticky top-0 z-50 w-full @container">
       <div

--- a/src/components/layout/header/header.types.ts
+++ b/src/components/layout/header/header.types.ts
@@ -1,7 +1,7 @@
 export interface IHeaderProps {
   /**
-   * 로그인 상태 여부. 기본값 false (비로그인)
-   * TODO: #100 auth session store 구현 후 useUserStore()로 교체
+   * 스토리북/프리뷰에서 로그인 상태를 강제로 지정할 때 사용합니다.
+   * 값이 없으면 auth session store 상태를 사용합니다.
    */
   isLoggedIn?: boolean;
 }

--- a/src/store/authSessionStore.ts
+++ b/src/store/authSessionStore.ts
@@ -1,0 +1,313 @@
+import { create } from "zustand";
+
+import { createClient } from "@/lib/supabase/client";
+
+import type { AuthError, Session, User } from "@supabase/supabase-js";
+
+type AuthErrorField = "email" | "password" | "confirmPassword" | null;
+
+type AuthSessionState = {
+  session: Session | null;
+  user: User | null;
+  isInitialized: boolean;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  errorMessage: string | null;
+  errorField: AuthErrorField;
+  statusMessage: string | null;
+};
+
+type AuthSessionActions = {
+  setSession: (session: Session | null) => void;
+  setInitialized: (isInitialized: boolean) => void;
+  setLoading: (isLoading: boolean) => void;
+  setErrorMessage: (errorMessage: string | null) => void;
+  setError: (params: { message: string | null; field?: AuthErrorField }) => void;
+  setStatusMessage: (statusMessage: string | null) => void;
+  initialize: (session: Session | null) => void;
+  clearSession: () => void;
+  signInWithGoogle: () => Promise<boolean>;
+  signInWithPassword: (email: string, password: string) => Promise<boolean>;
+  signUpWithPassword: (params: {
+    email: string;
+    password: string;
+    nickname?: string;
+  }) => Promise<boolean>;
+  signOut: () => Promise<void>;
+};
+
+type AuthSessionStore = AuthSessionState & AuthSessionActions;
+
+const initialState: AuthSessionState = {
+  session: null,
+  user: null,
+  isInitialized: false,
+  isLoading: true,
+  isAuthenticated: false,
+  errorMessage: null,
+  errorField: null,
+  statusMessage: null,
+};
+
+const getSessionState = (session: Session | null): Partial<AuthSessionState> => ({
+  session,
+  user: session?.user ?? null,
+  isAuthenticated: Boolean(session?.user),
+  isLoading: false,
+  errorMessage: null,
+  errorField: null,
+  statusMessage: null,
+});
+
+const mapAuthError = (
+  error: Pick<AuthError, "message" | "status" | "code">,
+  context: "signIn" | "signUp" | "oauth" | "signOut"
+): { message: string; field: AuthErrorField } => {
+  const normalizedMessage = error.message.toLowerCase();
+
+  if (
+    error.code === "invalid_credentials" ||
+    normalizedMessage.includes("invalid login credentials")
+  ) {
+    return {
+      message: "이메일 또는 비밀번호가 올바르지 않습니다.",
+      field: "password",
+    };
+  }
+
+  if (error.code === "email_not_confirmed" || normalizedMessage.includes("email not confirmed")) {
+    return {
+      message: "이메일 인증 후 다시 로그인해 주세요.",
+      field: "email",
+    };
+  }
+
+  if (
+    error.code === "user_already_exists" ||
+    normalizedMessage.includes("user already registered")
+  ) {
+    return {
+      message: "이미 가입된 이메일입니다.",
+      field: "email",
+    };
+  }
+
+  if (
+    normalizedMessage.includes("password should be at least") ||
+    normalizedMessage.includes("weak password")
+  ) {
+    return {
+      message: "비밀번호 조건을 다시 확인해 주세요.",
+      field: "password",
+    };
+  }
+
+  if (normalizedMessage.includes("rate limit") || normalizedMessage.includes("security purposes")) {
+    return {
+      message: "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.",
+      field: context === "signUp" ? "email" : null,
+    };
+  }
+
+  if (context === "signIn") {
+    return {
+      message: "로그인 중 문제가 발생했습니다. 입력값을 다시 확인해 주세요.",
+      field: "password",
+    };
+  }
+
+  if (context === "signUp") {
+    return {
+      message: "회원가입 중 문제가 발생했습니다. 다시 시도해 주세요.",
+      field: null,
+    };
+  }
+
+  if (context === "oauth") {
+    return {
+      message: "소셜 로그인 중 문제가 발생했습니다. 다시 시도해 주세요.",
+      field: null,
+    };
+  }
+
+  return {
+    message: "처리 중 문제가 발생했습니다. 다시 시도해 주세요.",
+    field: null,
+  };
+};
+
+export const useAuthSessionStore = create<AuthSessionStore>((set) => ({
+  ...initialState,
+
+  setSession: (session) =>
+    set({
+      ...getSessionState(session),
+    }),
+
+  setInitialized: (isInitialized) => set({ isInitialized }),
+
+  setLoading: (isLoading) => set({ isLoading }),
+
+  setErrorMessage: (errorMessage) => set({ errorMessage, errorField: null }),
+
+  setError: ({ message, field = null }) =>
+    set({
+      errorMessage: message,
+      errorField: field,
+      isLoading: false,
+    }),
+
+  setStatusMessage: (statusMessage) => set({ statusMessage }),
+
+  initialize: (session) =>
+    set({
+      ...getSessionState(session),
+      isInitialized: true,
+    }),
+
+  clearSession: () =>
+    set({
+      ...initialState,
+      isInitialized: true,
+      isLoading: false,
+    }),
+
+  signInWithGoogle: async () => {
+    const supabase = createClient();
+
+    set({
+      isLoading: true,
+      errorMessage: null,
+      statusMessage: null,
+    });
+
+    const redirectTo =
+      typeof window !== "undefined" ? `${window.location.origin}/auth/callback?next=/` : undefined;
+
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo,
+      },
+    });
+
+    if (error) {
+      const mappedError = mapAuthError(error, "oauth");
+      set({
+        isLoading: false,
+        errorMessage: mappedError.message,
+        errorField: mappedError.field,
+      });
+      return false;
+    }
+
+    return true;
+  },
+
+  signInWithPassword: async (email, password) => {
+    const supabase = createClient();
+
+    set({
+      isLoading: true,
+      errorMessage: null,
+      statusMessage: null,
+    });
+
+    const {
+      data: { session },
+      error,
+    } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (error) {
+      const mappedError = mapAuthError(error, "signIn");
+      set({
+        isLoading: false,
+        errorMessage: mappedError.message,
+        errorField: mappedError.field,
+      });
+      return false;
+    }
+
+    set({
+      ...getSessionState(session),
+      isInitialized: true,
+    });
+
+    return true;
+  },
+
+  signUpWithPassword: async ({ email, password, nickname }) => {
+    const supabase = createClient();
+
+    set({
+      isLoading: true,
+      errorMessage: null,
+      statusMessage: null,
+    });
+
+    const {
+      data: { session },
+      error,
+    } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        data: nickname ? { nickname } : undefined,
+        emailRedirectTo:
+          typeof window !== "undefined"
+            ? `${window.location.origin}/auth/callback?next=/`
+            : undefined,
+      },
+    });
+
+    if (error) {
+      const mappedError = mapAuthError(error, "signUp");
+      set({
+        isLoading: false,
+        errorMessage: mappedError.message,
+        errorField: mappedError.field,
+      });
+      return false;
+    }
+
+    set({
+      ...getSessionState(session),
+      isInitialized: true,
+      statusMessage: session
+        ? "회원가입이 완료되었습니다."
+        : "가입 확인 이메일을 확인한 뒤 로그인해 주세요.",
+    });
+
+    return true;
+  },
+
+  signOut: async () => {
+    const supabase = createClient();
+    set({
+      isLoading: true,
+      errorMessage: null,
+      statusMessage: null,
+    });
+
+    const { error } = await supabase.auth.signOut({ scope: "local" });
+
+    if (error) {
+      const mappedError = mapAuthError(error, "signOut");
+      set({
+        isLoading: false,
+        errorMessage: mappedError.message,
+        errorField: mappedError.field,
+      });
+      return;
+    }
+
+    set({
+      ...initialState,
+      isInitialized: true,
+      isLoading: false,
+    });
+  },
+}));


### PR DESCRIPTION
## PR 제목

feat / SS-100-AuthSessionStore - 인증 세션 스토어 구현

## PR 본문

### 반영 브랜치

SS-100-AuthSessionStore -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

- zustand 기반 auth session store를 추가해 세션, 유저, 로딩 상태를 전역으로 관리하도록 구성
- 앱 시작 시 세션을 동기화하는 AuthSessionSync를 추가하고, Header가 로그인 상태를 store 기준으로 읽도록 연결
- 이메일 로그인, 이메일 회원가입, 로그아웃 흐름을 store 액션과 연결
- 로그인/회원가입 에러를 한국어 문구로 매핑하고, Input의 error variant로 필드 에러가 표시되도록 반영
- OAuth callback route를 추가해 이후 소셜 로그인 확장이 가능한 구조로 정리함 (google cloud console 제 계정으로 만들어도 될지 몰라서 우선 대기)

Closes #100

### 테스트 결과 (선택)

### 스크린샷 (선택)


### 리뷰 요구사항(선택)