### PR TITLE
feat / ISSUE-27-taste-input-flow - taste 입력 플로우 1/2뎁스 구조 + Spotify/TMDB wrapper

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,11 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
-
-export default nextConfig;
+const nextConfig = {
+    images: {
+      remotePatterns: [
+        { protocol: "https", hostname: "image.tmdb.org" }, // TMDB 포스터/배경
+        { protocol: "https", hostname: "i.scdn.co" }, // Spotify 아티스트/앨범 (Premium 풀리면)
+      ],
+    },
+  };
+  
+  export default nextConfig;

--- a/src/app/api/spotify/route.ts
+++ b/src/app/api/spotify/route.ts
@@ -1,6 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export async function GET(_req: NextRequest) {
-  // TODO: Spotify 아티스트 검색
-  return NextResponse.json({ message: "not implemented" }, { status: 501 });
+import { searchArtists, searchTracks } from "@/lib/spotify/search";
+
+// GET /api/spotify?q=뉴진스&type=artist  (type: "artist" | "track", 기본 artist)
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const query = searchParams.get("q")?.trim();
+  const type = searchParams.get("type") === "track" ? "track" : "artist";
+
+  if (!query) {
+    return NextResponse.json({ message: "검색어(q)가 필요합니다." }, { status: 400 });
+  }
+
+  try {
+    const results = type === "track" ? await searchTracks(query) : await searchArtists(query);
+    return NextResponse.json({ results });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Spotify 검색 실패";
+    return NextResponse.json({ message }, { status: 500 });
+  }
 }

--- a/src/app/api/tmdb/route.ts
+++ b/src/app/api/tmdb/route.ts
@@ -1,6 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export async function GET(_req: NextRequest) {
-  // TODO: TMDB 영화 검색
-  return NextResponse.json({ message: "not implemented" }, { status: 501 });
+import { searchMovies } from "@/lib/tmdb/search";
+
+// GET /api/tmdb?q=기생충
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const query = searchParams.get("q")?.trim();
+
+  if (!query) {
+    return NextResponse.json({ message: "검색어(q)가 필요합니다." }, { status: 400 });
+  }
+
+  try {
+    const results = await searchMovies(query);
+    return NextResponse.json({ results });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "TMDB 검색 실패";
+    return NextResponse.json({ message }, { status: 500 });
+  }
 }

--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -5,10 +5,22 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { DomainGuard } from "@/components/domain/DomainGuard";
-import { BottomNav } from "@/components/layout/BottomNav";
-import { ProgressBar } from "@/components/layout/ProgressBar";
+import { MovieInput } from "@/components/domain/movieInput";
+import { MusicInput } from "@/components/domain/musicInput";
+import { TasteInputForm } from "@/components/domain/tasteInputForm";
 import { useTasteStore } from "@/store/tasteStore";
 import type { Domain } from "@/types/taste";
+// import { FashionInput } from "@/components/domain/fashionInput";
+// TODO: FashionInput 구현 방향 확인 필요
+// - 현재 FashionTasteCard는 placeholder 상태(return null)
+// - fashion detail step이 Music/Movie와 동일한 TasteCard 구조인지
+//   혹은 Step1(domain selection)과 동일한 카드 UI인지 확인 후 구현 예정
+// - 이미지 구조 및 선택 방식 확정 후 분기 연결
+{
+  /* {params.domain === "fashion" && (
+  <FashionInput />
+)} */
+}
 
 interface ITasteDetailPageProps {
   params: { domain: string };
@@ -38,23 +50,6 @@ const DETAIL_CONTENT: Record<
   },
 };
 
-// TODO: 디자인 시스템 Icon 세트로 교체 필요 (lucide-react 등 공용 라이브러리 사용 가능)
-const SearchIcon = () => (
-  <svg
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="11" cy="11" r="8" />
-    <path d="m21 21-4.3-4.3" />
-  </svg>
-);
-
 export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
   const router = useRouter();
   const musicSelections = useTasteStore((s) => s.musicSelections);
@@ -76,52 +71,24 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
 
   return (
     <DomainGuard domain={params.domain}>
-      <div className="page-container section-wrapper">
-        <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <h1 className="heading-section">
-              {content?.titleMain} <span className="text-orange-500">선택</span>
-            </h1>
-            <p className="text-sm text-stone-600">{content?.description}</p>
-          </div>
-          <ProgressBar currentStep={2} totalSteps={2} />
-        </header>
+      <TasteInputForm
+        domain={params.domain as Domain}
+        title={content.titleMain}
+        description={content.description}
+        searchPlaceholder={content.searchPlaceholder}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        isNextDisabled={!isReady}
+        onNext={handleAnalyze}
+      >
+        {params.domain === "music" && <MusicInput />}
 
-        {/* 
-          TODO: 디자인 시스템 SearchInput 컴포넌트로 교체 필요
-          - 현재 임시로 인라인 input + SVG 아이콘으로 구현
-          - 별도 브랜치에서 작업 중인 공통 SearchInput / TextField가 머지되면
-            <SearchInput value={searchQuery} onChange={...} placeholder={...} /> 형태로 교체
-          - 실제 검색 필터링 로직도 후속 이슈에서 추가 예정
-        */}
-        {/* 검색바 */}
-        <div className="relative mb-8 w-full">
-          <div className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-stone-400">
-            <SearchIcon />
-          </div>
-          <input
-            type="search"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder={content?.searchPlaceholder}
-            className="w-full rounded-full bg-white py-3 pl-12 pr-5 text-sm shadow-sm placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-500/30"
-          />
-        </div>
+        {params.domain === "movie" && <MovieInput />}
 
-        <section className="min-h-[60vh]">
-          {/* 카드 그리드 - 다음 이슈에서 */}
-          <p className="text-stone-400">선택 UI 영역</p>
-        </section>
-
-        <BottomNav
-          prevPath={`/taste/${params.domain}`}
-          prevLabel="이전으로"
-          nextLabel="스타일 분석 시작하기"
-          isNextDisabled={!isReady}
-          onNext={handleAnalyze}
-          isLastStep
-        />
-      </div>
+        {/* {params.domain === "fashion" && (
+        <FashionInput />
+      )} */}
+      </TasteInputForm>
     </DomainGuard>
   );
 }

--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -1,26 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useRouter } from "next/navigation";
 
 import { DomainGuard } from "@/components/domain/DomainGuard";
-import { MovieInput } from "@/components/domain/movieInput";
-import { MusicInput } from "@/components/domain/musicInput";
+import { MovieTasteCard } from "@/components/domain/movieTasteCard";
+import { MusicTasteCard } from "@/components/domain/musicTasteCard";
 import { TasteInputForm } from "@/components/domain/tasteInputForm";
 import { useTasteStore } from "@/store/tasteStore";
 import type { Domain } from "@/types/taste";
-// import { FashionInput } from "@/components/domain/fashionInput";
-// TODO: FashionInput 구현 방향 확인 필요
-// - 현재 FashionTasteCard는 placeholder 상태(return null)
-// - fashion detail step이 Music/Movie와 동일한 TasteCard 구조인지
-//   혹은 Step1(domain selection)과 동일한 카드 UI인지 확인 후 구현 예정
-// - 이미지 구조 및 선택 방식 확정 후 분기 연결
-{
-  /* {params.domain === "fashion" && (
-  <FashionInput />
-)} */
-}
 
 interface ITasteDetailPageProps {
   params: { domain: string };
@@ -42,37 +31,90 @@ const DETAIL_CONTENT: Record<
       "가장 선호하는 스타일의 영화를 선택해 주세요. 선택한 영화들이 당신의 스타일 프로필을 구성합니다.",
     searchPlaceholder: "영화 검색",
   },
-  fashion: {
-    titleMain: "패션 취향",
-    description:
-      "가장 선호하는 스타일의 룩을 선택해 주세요. 선택한 룩들이 당신의 패션 취향 프로필을 구성합니다.",
-    searchPlaceholder: "스타일 검색",
-  },
+  // fashion은 detail(2뎁스) 미사용 — 타입 충족용
+  fashion: { titleMain: "", description: "", searchPlaceholder: "" },
 };
+
+// 2뎁스 mock 카드 데이터 (TODO: #41 Spotify 검색 / #44 TMDB 연동으로 교체)
+const MOCK_ARTISTS = [
+  { id: "1", title: "NewJeans", genre: "Y2K Pop", imageUrl: "" },
+  { id: "2", title: "Keshi", genre: "Lo-fi", imageUrl: "" },
+  { id: "3", title: "IU", genre: "Ballad", imageUrl: "" },
+];
+
+const MOCK_MOVIES = [
+  { id: 1, title: "Interstellar", genre: "Sci-Fi", imageUrl: "" },
+  { id: 2, title: "La La Land", genre: "Romance", imageUrl: "" },
+  { id: 3, title: "Parasite", genre: "Thriller", imageUrl: "" },
+];
 
 export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
   const router = useRouter();
+  const domain = params.domain as Domain;
+
   const musicSelections = useTasteStore((s) => s.musicSelections);
+  const movieSelections = useTasteStore((s) => s.movieSelections);
+  const addMusicSelection = useTasteStore((s) => s.addMusicSelection);
+  const removeMusicSelection = useTasteStore((s) => s.removeMusicSelection);
+  const addMovieSelection = useTasteStore((s) => s.addMovieSelection);
+  const removeMovieSelection = useTasteStore((s) => s.removeMovieSelection);
 
-  // TODO: 도메인별 selection 체크 로직 분기 필요
-  const isReady = musicSelections.length > 0;
+  // fashion은 2뎁스 미사용 → 1뎁스로 되돌림 (렌더 중 호출 X, useEffect)
+  useEffect(() => {
+    if (domain === "fashion") router.replace("/taste/fashion");
+  }, [domain, router]);
 
-  // TODO: 실제 검색 로직 (필터링은 다음 이슈에서)
+  // 도메인별 선택 상태로 분기 (music/movie 영향 분리)
+  const isReady =
+    domain === "music"
+      ? musicSelections.length > 0
+      : domain === "movie"
+        ? movieSelections.length > 0
+        : false;
+
   const [searchQuery, setSearchQuery] = useState("");
-
-  const content = DETAIL_CONTENT[params.domain as Domain];
+  const content = DETAIL_CONTENT[domain];
 
   const handleAnalyze = () => {
-    // TODO: 실제 분석 API 응답으로 받은 resultId 사용
-    // 현재는 /result/[id] 페이지의 mock 데이터(mock-1) 매칭용
-    const tempResultId = "mock-1";
-    router.push(`/result/${tempResultId}`);
+    // TODO: 실제 분석 API 응답의 resultId 사용
+    router.push("/result/mock-1");
   };
+
+  const handleSelectArtist = (artist: (typeof MOCK_ARTISTS)[number]) => {
+    if (musicSelections.some((item) => item.id === artist.id)) {
+      removeMusicSelection(artist.id);
+      return;
+    }
+    addMusicSelection({
+      id: artist.id,
+      name: artist.title,
+      image: artist.imageUrl,
+      genres: [artist.genre],
+      previewUrl: "",
+    });
+  };
+
+  const handleSelectMovie = (movie: (typeof MOCK_MOVIES)[number]) => {
+    if (movieSelections.some((item) => item.id === movie.id)) {
+      removeMovieSelection(movie.id);
+      return;
+    }
+    addMovieSelection({
+      id: movie.id,
+      title: movie.title,
+      posterPath: movie.imageUrl,
+      backdropPath: "",
+      genres: [movie.genre],
+      releaseYear: 2024,
+    });
+  };
+
+  if (domain === "fashion") return null;
 
   return (
     <DomainGuard domain={params.domain}>
       <TasteInputForm
-        domain={params.domain as Domain}
+        domain={domain}
         title={content.titleMain}
         description={content.description}
         searchPlaceholder={content.searchPlaceholder}
@@ -81,13 +123,34 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
         isNextDisabled={!isReady}
         onNext={handleAnalyze}
       >
-        {params.domain === "music" && <MusicInput />}
+        {/* 2뎁스: TasteCard 그리드 */}
+        <div className="grid-cols-responsive">
+          {domain === "music" &&
+            MOCK_ARTISTS.map((artist) => (
+              <MusicTasteCard
+                key={artist.id}
+                domain="music"
+                title={artist.title}
+                genre={artist.genre}
+                imageUrl={artist.imageUrl}
+                selected={musicSelections.some((item) => item.id === artist.id)}
+                onClick={() => handleSelectArtist(artist)}
+              />
+            ))}
 
-        {params.domain === "movie" && <MovieInput />}
-
-        {/* {params.domain === "fashion" && (
-        <FashionInput />
-      )} */}
+          {domain === "movie" &&
+            MOCK_MOVIES.map((movie) => (
+              <MovieTasteCard
+                key={movie.id}
+                domain="movie"
+                title={movie.title}
+                genre={movie.genre}
+                imageUrl={movie.imageUrl}
+                selected={movieSelections.some((item) => item.id === movie.id)}
+                onClick={() => handleSelectMovie(movie)}
+              />
+            ))}
+        </div>
       </TasteInputForm>
     </DomainGuard>
   );

--- a/src/app/taste/[domain]/page.tsx
+++ b/src/app/taste/[domain]/page.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import { DomainGuard } from "@/components/domain/DomainGuard";
+import { FashionInput } from "@/components/domain/fashionInput";
+import { MovieInput } from "@/components/domain/movieInput";
+import { MusicInput } from "@/components/domain/musicInput";
 import { BottomNav } from "@/components/layout/BottomNav";
 import { ProgressBar } from "@/components/layout/ProgressBar";
+import { useTasteStore } from "@/store/tasteStore";
 import type { Domain } from "@/types/taste";
 
 interface ITastePageProps {
   params: { domain: string };
 }
 
-// 도메인별 콘텐츠 매핑
 const DOMAIN_CONTENT: Record<Domain, { titleMain: string; description: string }> = {
   music: {
     titleMain: "뮤직 스타일",
@@ -25,37 +28,42 @@ const DOMAIN_CONTENT: Record<Domain, { titleMain: string; description: string }>
   },
 };
 
-export default function TasteStep1Page({ params }: ITastePageProps) {
-  // TODO: 실제 선택값으로 교체
-  const isStyleSelected = true;
+// TODO: 실제 분석 resultId로 교체 (현재 mock 매칭용)
+const RESULT_PATH = "/result/mock-1";
 
-  // DomainGuard가 유효성 검증하므로 안전하게 캐스팅
-  const content = DOMAIN_CONTENT[params.domain as Domain];
+export default function TasteStep1Page({ params }: ITastePageProps) {
+  const domain = params.domain as Domain;
+  const content = DOMAIN_CONTENT[domain];
+
+  // 1뎁스 스타일 선택 여부로 다음 버튼 활성화
+  const selectedStyles = useTasteStore((s) => s.selectedStyles);
+  const isStyleSelected = Boolean(selectedStyles[domain]);
+
+  // fashion은 detail(2뎁스) 없이 결과로 직행
+  const isFashion = domain === "fashion";
+  const nextPath = isFashion ? RESULT_PATH : `/taste/${domain}/detail`;
+  const totalSteps = isFashion ? 1 : 2;
 
   return (
     <DomainGuard domain={params.domain}>
       <div className="page-container section-wrapper">
         <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div className="flex flex-col gap-4">
-            <h1 className="type-headline-lg">
-              {content?.titleMain} <span className="text-orange-500">셀렉션</span>
+            <h1 className="type-headline-lg keep-all">
+              {content?.titleMain} <span className="text-primary-container">셀렉션</span>
             </h1>
-
-            <p className="type-body-lg text-stone-600">{content?.description}</p>
+            <p className="type-body-lg keep-all text-on-surface-variant">{content?.description}</p>
           </div>
-          <ProgressBar currentStep={1} totalSteps={2} />
+          <ProgressBar currentStep={1} totalSteps={totalSteps} />
         </header>
 
         <section className="min-h-[60vh]">
-          {/* 선택 UI - 다음 이슈에서 */}
-          <p className="text-stone-400">선택 UI 영역</p>
+          {domain === "music" && <MusicInput />}
+          {domain === "movie" && <MovieInput />}
+          {domain === "fashion" && <FashionInput />}
         </section>
 
-        <BottomNav
-          prevPath="/select"
-          nextPath={`/taste/${params.domain}/detail`}
-          isNextDisabled={!isStyleSelected}
-        />
+        <BottomNav prevPath="/select" nextPath={nextPath} isNextDisabled={!isStyleSelected} />
       </div>
     </DomainGuard>
   );

--- a/src/app/taste/[domain]/page.tsx
+++ b/src/app/taste/[domain]/page.tsx
@@ -36,11 +36,12 @@ export default function TasteStep1Page({ params }: ITastePageProps) {
     <DomainGuard domain={params.domain}>
       <div className="page-container section-wrapper">
         <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-          <div>
-            <h1 className="heading-section">
+          <div className="flex flex-col gap-4">
+            <h1 className="type-headline-lg">
               {content?.titleMain} <span className="text-orange-500">셀렉션</span>
             </h1>
-            <p className="text-sm text-stone-600">{content?.description}</p>
+
+            <p className="type-body-lg text-stone-600">{content?.description}</p>
           </div>
           <ProgressBar currentStep={1} totalSteps={2} />
         </header>

--- a/src/components/domain/fashionInput/FashionInput.tsx
+++ b/src/components/domain/fashionInput/FashionInput.tsx
@@ -1,58 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { StyleSelectList } from "@/components/domain/styleSelectList";
+import type { IStyleOption } from "@/components/domain/styleSelectList";
 
-import { FashionTasteCard } from "@/components/domain/fashionTasteCard";
-
-const STYLE_OPTIONS = [
-  {
-    id: "minimal",
-    title: "Minimal",
-    genre: "Clean",
-    imageUrl: "",
-  },
-  {
-    id: "street",
-    title: "Street",
-    genre: "Urban",
-    imageUrl: "",
-  },
-  {
-    id: "vintage",
-    title: "Vintage",
-    genre: "Classic",
-    imageUrl: "",
-  },
-  {
-    id: "sporty",
-    title: "Sporty",
-    genre: "Casual",
-    imageUrl: "",
-  },
+// 1뎁스 패션 스타일 옵션 (TODO: 실제 피그마 데이터로 교체)
+const FASHION_STYLES: IStyleOption[] = [
+  { id: "minimal", title: "Minimal" },
+  { id: "street", title: "Street" },
+  { id: "vintage", title: "Vintage" },
+  { id: "sporty", title: "Sporty" },
+  { id: "romantic", title: "Romantic" },
 ];
 
-export function FashionInput() {
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
-
-  const handleSelect = (styleId: string) => {
-    setSelectedIds((prev) =>
-      prev.includes(styleId) ? prev.filter((id) => id !== styleId) : [...prev, styleId]
-    );
-  };
-
-  return (
-    <div className="grid-cols-responsive">
-      {STYLE_OPTIONS.map((item) => (
-        <FashionTasteCard
-          key={item.id}
-          domain="fashion"
-          title={item.title}
-          genre={item.genre}
-          imageUrl={item.imageUrl}
-          selected={selectedIds.includes(item.id)}
-          onClick={() => handleSelect(item.id)}
-        />
-      ))}
-    </div>
-  );
-}
+export const FashionInput = () => {
+  return <StyleSelectList domain="fashion" options={FASHION_STYLES} />;
+};

--- a/src/components/domain/fashionInput/FashionInput.tsx
+++ b/src/components/domain/fashionInput/FashionInput.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+
+import { FashionTasteCard } from "@/components/domain/fashionTasteCard";
+
+const STYLE_OPTIONS = [
+  {
+    id: "minimal",
+    title: "Minimal",
+    genre: "Clean",
+    imageUrl: "",
+  },
+  {
+    id: "street",
+    title: "Street",
+    genre: "Urban",
+    imageUrl: "",
+  },
+  {
+    id: "vintage",
+    title: "Vintage",
+    genre: "Classic",
+    imageUrl: "",
+  },
+  {
+    id: "sporty",
+    title: "Sporty",
+    genre: "Casual",
+    imageUrl: "",
+  },
+];
+
+export function FashionInput() {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const handleSelect = (styleId: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(styleId) ? prev.filter((id) => id !== styleId) : [...prev, styleId]
+    );
+  };
+
+  return (
+    <div className="grid-cols-responsive">
+      {STYLE_OPTIONS.map((item) => (
+        <FashionTasteCard
+          key={item.id}
+          domain="fashion"
+          title={item.title}
+          genre={item.genre}
+          imageUrl={item.imageUrl}
+          selected={selectedIds.includes(item.id)}
+          onClick={() => handleSelect(item.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/domain/fashionInput/index.ts
+++ b/src/components/domain/fashionInput/index.ts
@@ -1,0 +1,1 @@
+export { FashionInput } from "./FashionInput";

--- a/src/components/domain/fashionTasteCard/FashionTasteCard.tsx
+++ b/src/components/domain/fashionTasteCard/FashionTasteCard.tsx
@@ -1,3 +1,2 @@
-export const FashionTasteCard = () => {
-  return null;
-};
+// TasteCard 공통 컴포넌트로 통합 — SS-155
+export { TasteCard as FashionTasteCard } from "@/components/domain/tasteCard";

--- a/src/components/domain/movieInput/MovieInput.tsx
+++ b/src/components/domain/movieInput/MovieInput.tsx
@@ -1,77 +1,17 @@
 "use client";
 
-import { MovieTasteCard } from "@/components/domain/movieTasteCard";
-import { useTasteStore } from "@/store/tasteStore";
+import { StyleSelectList } from "@/components/domain/styleSelectList";
+import type { IStyleOption } from "@/components/domain/styleSelectList";
 
-const MOCK_MOVIES = [
-  {
-    id: 1,
-    title: "Interstellar",
-    genre: "Sci-Fi",
-    imageUrl: "",
-  },
-  {
-    id: 2,
-    title: "La La Land",
-    genre: "Romance",
-    imageUrl: "",
-  },
-  {
-    id: 3,
-    title: "Parasite",
-    genre: "Thriller",
-    imageUrl: "",
-  },
-  {
-    id: 4,
-    title: "Parasite",
-    genre: "Thriller",
-    imageUrl: "",
-  },
+// 1뎁스 영화 스타일 옵션 (TODO: 실제 피그마 데이터로 교체)
+const MOVIE_STYLES: IStyleOption[] = [
+  { id: "neo-noir", title: "Neo Noir" },
+  { id: "coming-of-age", title: "Coming Of Age" },
+  { id: "sci-fi-epic", title: "Sci-Fi Epic" },
+  { id: "slow-burn", title: "Slow Burn" },
+  { id: "feel-good", title: "Feel Good" },
 ];
 
-export function MovieInput() {
-  const movieSelections = useTasteStore((s) => s.movieSelections);
-
-  const addMovieSelection = useTasteStore((s) => s.addMovieSelection);
-
-  const removeMovieSelection = useTasteStore((s) => s.removeMovieSelection);
-
-  const handleSelect = (movie: (typeof MOCK_MOVIES)[number]) => {
-    const isSelected = movieSelections.some((item) => item.id === movie.id);
-
-    if (isSelected) {
-      removeMovieSelection(movie.id);
-      return;
-    }
-
-    addMovieSelection({
-      id: movie.id,
-      title: movie.title,
-      posterPath: movie.imageUrl,
-      backdropPath: "",
-      genres: [movie.genre],
-      releaseYear: 2024,
-    });
-  };
-
-  return (
-    <div className="grid-cols-responsive">
-      {MOCK_MOVIES.map((movie) => {
-        const isSelected = movieSelections.some((item) => item.id === movie.id);
-
-        return (
-          <MovieTasteCard
-            key={movie.id}
-            domain="movie"
-            title={movie.title}
-            genre={movie.genre}
-            imageUrl={movie.imageUrl}
-            selected={isSelected}
-            onClick={() => handleSelect(movie)}
-          />
-        );
-      })}
-    </div>
-  );
-}
+export const MovieInput = () => {
+  return <StyleSelectList domain="movie" options={MOVIE_STYLES} />;
+};

--- a/src/components/domain/movieInput/MovieInput.tsx
+++ b/src/components/domain/movieInput/MovieInput.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { MovieTasteCard } from "@/components/domain/movieTasteCard";
+import { useTasteStore } from "@/store/tasteStore";
+
+const MOCK_MOVIES = [
+  {
+    id: 1,
+    title: "Interstellar",
+    genre: "Sci-Fi",
+    imageUrl: "",
+  },
+  {
+    id: 2,
+    title: "La La Land",
+    genre: "Romance",
+    imageUrl: "",
+  },
+  {
+    id: 3,
+    title: "Parasite",
+    genre: "Thriller",
+    imageUrl: "",
+  },
+  {
+    id: 4,
+    title: "Parasite",
+    genre: "Thriller",
+    imageUrl: "",
+  },
+];
+
+export function MovieInput() {
+  const movieSelections = useTasteStore((s) => s.movieSelections);
+
+  const addMovieSelection = useTasteStore((s) => s.addMovieSelection);
+
+  const removeMovieSelection = useTasteStore((s) => s.removeMovieSelection);
+
+  const handleSelect = (movie: (typeof MOCK_MOVIES)[number]) => {
+    const isSelected = movieSelections.some((item) => item.id === movie.id);
+
+    if (isSelected) {
+      removeMovieSelection(movie.id);
+      return;
+    }
+
+    addMovieSelection({
+      id: movie.id,
+      title: movie.title,
+      posterPath: movie.imageUrl,
+      backdropPath: "",
+      genres: [movie.genre],
+      releaseYear: 2024,
+    });
+  };
+
+  return (
+    <div className="grid-cols-responsive">
+      {MOCK_MOVIES.map((movie) => {
+        const isSelected = movieSelections.some((item) => item.id === movie.id);
+
+        return (
+          <MovieTasteCard
+            key={movie.id}
+            domain="movie"
+            title={movie.title}
+            genre={movie.genre}
+            imageUrl={movie.imageUrl}
+            selected={isSelected}
+            onClick={() => handleSelect(movie)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/domain/movieInput/index.ts
+++ b/src/components/domain/movieInput/index.ts
@@ -1,0 +1,1 @@
+export { MovieInput } from "./MovieInput";

--- a/src/components/domain/musicInput/MusicInput.tsx
+++ b/src/components/domain/musicInput/MusicInput.tsx
@@ -1,76 +1,17 @@
 "use client";
 
-import { MusicTasteCard } from "@/components/domain/musicTasteCard";
-import { useTasteStore } from "@/store/tasteStore";
+import { StyleSelectList } from "@/components/domain/styleSelectList";
+import type { IStyleOption } from "@/components/domain/styleSelectList";
 
-const MOCK_ARTISTS = [
-  {
-    id: "1",
-    title: "NewJeans",
-    genre: "Y2K Pop",
-    imageUrl: "",
-  },
-  {
-    id: "2",
-    title: "Keshi",
-    genre: "Lo-fi",
-    imageUrl: "",
-  },
-  {
-    id: "3",
-    title: "IU",
-    genre: "Ballad",
-    imageUrl: "",
-  },
-  {
-    id: "4",
-    title: "IU",
-    genre: "Ballad",
-    imageUrl: "",
-  },
+// 1뎁스 뮤직 스타일 옵션
+const MUSIC_STYLES: IStyleOption[] = [
+  { id: "contemporary-jazz", title: "Contemporary Jazz" },
+  { id: "pop-iconic", title: "Pop Iconic" },
+  { id: "electronic-pop", title: "Electronic Pop" },
+  { id: "moody-indie", title: "Moody Indie" },
+  { id: "street-beats", title: "Street Beats" },
 ];
 
-export function MusicInput() {
-  const musicSelections = useTasteStore((s) => s.musicSelections);
-
-  const addMusicSelection = useTasteStore((s) => s.addMusicSelection);
-
-  const removeMusicSelection = useTasteStore((s) => s.removeMusicSelection);
-
-  const handleSelect = (artist: (typeof MOCK_ARTISTS)[number]) => {
-    const isSelected = musicSelections.some((item) => item.id === artist.id);
-
-    if (isSelected) {
-      removeMusicSelection(artist.id);
-      return;
-    }
-
-    addMusicSelection({
-      id: artist.id,
-      name: artist.title,
-      image: artist.imageUrl,
-      genres: [artist.genre],
-      previewUrl: "",
-    });
-  };
-
-  return (
-    <div className="grid-cols-responsive">
-      {MOCK_ARTISTS.map((artist) => {
-        const isSelected = musicSelections.some((item) => item.id === artist.id);
-
-        return (
-          <MusicTasteCard
-            key={artist.id}
-            domain="music"
-            title={artist.title}
-            genre={artist.genre}
-            imageUrl={artist.imageUrl}
-            selected={isSelected}
-            onClick={() => handleSelect(artist)}
-          />
-        );
-      })}
-    </div>
-  );
-}
+export const MusicInput = () => {
+  return <StyleSelectList domain="music" options={MUSIC_STYLES} />;
+};

--- a/src/components/domain/musicInput/MusicInput.tsx
+++ b/src/components/domain/musicInput/MusicInput.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { MusicTasteCard } from "@/components/domain/musicTasteCard";
+import { useTasteStore } from "@/store/tasteStore";
+
+const MOCK_ARTISTS = [
+  {
+    id: "1",
+    title: "NewJeans",
+    genre: "Y2K Pop",
+    imageUrl: "",
+  },
+  {
+    id: "2",
+    title: "Keshi",
+    genre: "Lo-fi",
+    imageUrl: "",
+  },
+  {
+    id: "3",
+    title: "IU",
+    genre: "Ballad",
+    imageUrl: "",
+  },
+  {
+    id: "4",
+    title: "IU",
+    genre: "Ballad",
+    imageUrl: "",
+  },
+];
+
+export function MusicInput() {
+  const musicSelections = useTasteStore((s) => s.musicSelections);
+
+  const addMusicSelection = useTasteStore((s) => s.addMusicSelection);
+
+  const removeMusicSelection = useTasteStore((s) => s.removeMusicSelection);
+
+  const handleSelect = (artist: (typeof MOCK_ARTISTS)[number]) => {
+    const isSelected = musicSelections.some((item) => item.id === artist.id);
+
+    if (isSelected) {
+      removeMusicSelection(artist.id);
+      return;
+    }
+
+    addMusicSelection({
+      id: artist.id,
+      name: artist.title,
+      image: artist.imageUrl,
+      genres: [artist.genre],
+      previewUrl: "",
+    });
+  };
+
+  return (
+    <div className="grid-cols-responsive">
+      {MOCK_ARTISTS.map((artist) => {
+        const isSelected = musicSelections.some((item) => item.id === artist.id);
+
+        return (
+          <MusicTasteCard
+            key={artist.id}
+            domain="music"
+            title={artist.title}
+            genre={artist.genre}
+            imageUrl={artist.imageUrl}
+            selected={isSelected}
+            onClick={() => handleSelect(artist)}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/domain/musicInput/index.ts
+++ b/src/components/domain/musicInput/index.ts
@@ -1,0 +1,1 @@
+export { MusicInput } from "./MusicInput";

--- a/src/components/domain/styleSelectList/StyleSelectList.tsx
+++ b/src/components/domain/styleSelectList/StyleSelectList.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Icon } from "@/components/ui/Icon";
+import { useTasteStore } from "@/store/tasteStore";
+
+import type { IStyleSelectListProps } from "./styleSelectList.types";
+
+// ── StyleSelectList ─────────────────────────────────────────────────────────
+// 1뎁스 스타일/무드 선택 — 리스트 + 프리뷰 UI (TasteCard 미사용)
+
+export const StyleSelectList = ({ domain, options }: IStyleSelectListProps) => {
+  const selectedStyles = useTasteStore((s) => s.selectedStyles);
+  const setSelectedStyle = useTasteStore((s) => s.setSelectedStyle);
+
+  const selectedId = selectedStyles[domain] ?? null;
+  const selectedOption = options.find((option) => option.id === selectedId) ?? null;
+
+  return (
+    <div className="flex flex-col gap-10 lg:flex-row lg:gap-16">
+      {/* ── 스타일 리스트 ─────────────────────────────────────────────── */}
+      <ul className="flex-1">
+        {options.map((option, index) => {
+          const isSelected = option.id === selectedId;
+
+          return (
+            <li key={option.id} className="border-b border-outline-variant">
+              <button
+                type="button"
+                onClick={() => setSelectedStyle(domain, option.id)}
+                aria-pressed={isSelected}
+                className="group flex w-full items-baseline gap-5 py-6 text-left"
+              >
+                <span className="font-label text-label-sm text-on-surface-variant/50">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span
+                  className={[
+                    "font-headline font-black uppercase keep-all leading-tight",
+                    "text-headline-md md:text-headline-lg",
+                    "transition-colors duration-200",
+                    isSelected
+                      ? "text-primary-container"
+                      : "text-on-background/25 group-hover:text-on-background/50",
+                  ].join(" ")}
+                >
+                  {option.title}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* ── 프리뷰 카드 (데스크탑) ────────────────────────────────────── */}
+      <aside className="hidden lg:block lg:w-[360px] lg:shrink-0">
+        <div className="sticky top-8 flex h-[420px] flex-col justify-end rounded-[2.5rem] bg-surface-variant p-8 editorial-shadow">
+          <div className="flex items-end justify-between gap-4">
+            <div className="flex flex-col gap-1">
+              <span className="font-label text-label-sm uppercase text-on-surface-variant/60">
+                Preview Selection
+              </span>
+              <span className="font-headline font-black text-headline-sm text-on-background keep-all">
+                {selectedOption?.title ?? "—"}
+              </span>
+            </div>
+            <div
+              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-on-background"
+              aria-hidden="true"
+            >
+              <Icon name="arrowUpRight" className="text-white" size={18} />
+            </div>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+};

--- a/src/components/domain/styleSelectList/index.ts
+++ b/src/components/domain/styleSelectList/index.ts
@@ -1,0 +1,2 @@
+export { StyleSelectList } from "./StyleSelectList";
+export type { IStyleOption, IStyleSelectListProps } from "./styleSelectList.types";

--- a/src/components/domain/styleSelectList/styleSelectList.types.ts
+++ b/src/components/domain/styleSelectList/styleSelectList.types.ts
@@ -1,0 +1,11 @@
+import type { Domain } from "@/types/taste";
+
+export interface IStyleOption {
+  id: string;
+  title: string;
+}
+
+export interface IStyleSelectListProps {
+  domain: Domain;
+  options: IStyleOption[];
+}

--- a/src/components/domain/tasteInputForm/TasteInputForm.tsx
+++ b/src/components/domain/tasteInputForm/TasteInputForm.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { BottomNav } from "@/components/layout/BottomNav";
+import { ProgressBar } from "@/components/layout/ProgressBar";
+
+import type { ITasteInputFormProps } from "./tasteInputForm.types";
+
+// TODO: 디자인 시스템 Icon 세트로 교체 필요
+// (lucide-react 등 공용 라이브러리 사용 가능)
+const SearchIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.3-4.3" />
+  </svg>
+);
+
+export function TasteInputForm({
+  title,
+  description,
+  searchPlaceholder,
+  searchQuery,
+  onSearchChange,
+  domain,
+  children,
+  isNextDisabled,
+  onNext,
+}: ITasteInputFormProps) {
+  return (
+    <div className="page-container section-wrapper">
+      <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="flex flex-col gap-4">
+          <h1 className="type-headline-lg">
+            {title}
+            <span className="text-orange-500"> 선택</span>
+          </h1>
+
+          <p className="type-body-lg text-stone-600">{description}</p>
+        </div>
+
+        <ProgressBar currentStep={2} totalSteps={2} />
+      </header>
+
+      {/* 
+        TODO: 디자인 시스템 SearchInput 컴포넌트로 교체 필요
+        - 현재 임시로 인라인 input + SVG 아이콘으로 구현
+        - 별도 브랜치에서 작업 중인 공통 SearchInput / TextField가 머지되면
+          <SearchInput
+            value={searchQuery}
+            onChange={...}
+            placeholder={searchPlaceholder}
+          />
+          형태로 교체
+        - 실제 검색 필터링 로직은 후속 이슈에서 추가 예정
+      */}
+      {/* 검색바 */}
+      <div className="relative mb-8 w-full">
+        <div className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-stone-400">
+          <SearchIcon />
+        </div>
+
+        <input
+          type="search"
+          value={searchQuery}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder={searchPlaceholder}
+          className="w-full rounded-full bg-white py-3 pl-12 pr-5 text-sm shadow-sm placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-500/30"
+        />
+      </div>
+
+      <section className="min-h-[60vh]">{children}</section>
+
+      <BottomNav
+        prevPath={`/taste/${domain}`}
+        prevLabel="이전으로"
+        nextLabel="스타일 분석 시작하기"
+        isNextDisabled={isNextDisabled}
+        onNext={onNext}
+        isLastStep
+      />
+    </div>
+  );
+}

--- a/src/components/domain/tasteInputForm/index.ts
+++ b/src/components/domain/tasteInputForm/index.ts
@@ -1,0 +1,1 @@
+export { TasteInputForm } from "./TasteInputForm";

--- a/src/components/domain/tasteInputForm/tasteInputForm.types.ts
+++ b/src/components/domain/tasteInputForm/tasteInputForm.types.ts
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+
+import type { Domain } from "@/types/taste";
+
+export interface ITasteInputFormProps {
+  title: string;
+  description: string;
+  searchPlaceholder: string;
+
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+
+  domain: Domain;
+  children: ReactNode;
+
+  isNextDisabled?: boolean;
+  onNext?: () => void;
+}

--- a/src/lib/spotify.ts
+++ b/src/lib/spotify.ts
@@ -1,2 +1,0 @@
-// TODO: Spotify API 클라이언트
-export {};

--- a/src/lib/spotify/audioFeatures.ts
+++ b/src/lib/spotify/audioFeatures.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import { spotifyFetch } from "./client";
+
+export type AudioFeatures = {
+  id: string;
+  danceability: number;
+  energy: number;
+  valence: number;
+  tempo: number;
+  acousticness: number;
+  instrumentalness: number;
+  speechiness: number;
+  liveness: number;
+  loudness: number;
+};
+
+type AudioFeaturesManyResponse = {
+  audio_features: (AudioFeatures | null)[];
+};
+
+// 단일 트랙 audio features
+export const getAudioFeatures = async (trackId: string): Promise<AudioFeatures> => {
+  return spotifyFetch<AudioFeatures>(`/audio-features/${trackId}`);
+};
+
+// 여러 트랙 (최대 100개) — 응답의 null 항목은 제거
+export const getAudioFeaturesMany = async (trackIds: string[]): Promise<AudioFeatures[]> => {
+  if (trackIds.length === 0) return [];
+
+  const ids = trackIds.slice(0, 100).join(",");
+  const data = await spotifyFetch<AudioFeaturesManyResponse>(`/audio-features?ids=${ids}`);
+
+  return data.audio_features.filter((f): f is AudioFeatures => f !== null);
+};

--- a/src/lib/spotify/auth.ts
+++ b/src/lib/spotify/auth.ts
@@ -1,0 +1,72 @@
+import "server-only";
+
+const TOKEN_URL = "https://accounts.spotify.com/api/token";
+const EXPIRY_BUFFER_MS = 60_000; // 만료 60초 전 선제 갱신
+
+type SpotifyTokenResponse = {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+};
+
+type CachedToken = {
+  accessToken: string;
+  expiresAt: number; // epoch ms
+};
+
+let cachedToken: CachedToken | null = null;
+let inFlight: Promise<CachedToken> | null = null;
+
+const getCredentials = () => {
+  const clientId = process.env.SPOTIFY_CLIENT_ID;
+  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    throw new Error("Spotify 환경변수 누락: SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET 확인");
+  }
+
+  return { clientId, clientSecret };
+};
+
+const fetchNewToken = async (): Promise<CachedToken> => {
+  const { clientId, clientSecret } = getCredentials();
+  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${basic}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ grant_type: "client_credentials" }),
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Spotify 토큰 발급 실패 (${res.status}): ${detail}`);
+  }
+
+  const data = (await res.json()) as SpotifyTokenResponse;
+
+  return {
+    accessToken: data.access_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  };
+};
+
+export const getSpotifyToken = async (forceRefresh = false): Promise<string> => {
+  const valid = cachedToken && cachedToken.expiresAt - EXPIRY_BUFFER_MS > Date.now();
+
+  if (!forceRefresh && valid) return cachedToken!.accessToken;
+
+  // 동시 요청이 토큰을 중복 발급하지 않도록 in-flight 공유
+  if (!inFlight) {
+    inFlight = fetchNewToken().finally(() => {
+      inFlight = null;
+    });
+  }
+
+  cachedToken = await inFlight;
+  return cachedToken.accessToken;
+};

--- a/src/lib/spotify/client.ts
+++ b/src/lib/spotify/client.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import { getSpotifyToken } from "./auth";
+
+const API_BASE = "https://api.spotify.com/v1";
+
+export const spotifyFetch = async <T>(
+  endpoint: string,
+  init?: RequestInit,
+  retry = true
+): Promise<T> => {
+  const token = await getSpotifyToken();
+
+  const res = await fetch(`${API_BASE}${endpoint}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...init?.headers,
+    },
+    cache: "no-store",
+  });
+
+  // 토큰 만료(401) 시 강제 갱신 후 1회 재시도
+  if (res.status === 401 && retry) {
+    await getSpotifyToken(true);
+    return spotifyFetch<T>(endpoint, init, false);
+  }
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Spotify API 오류 (${res.status}): ${detail}`);
+  }
+
+  return res.json() as Promise<T>;
+};

--- a/src/lib/spotify/preview.ts
+++ b/src/lib/spotify/preview.ts
@@ -1,0 +1,20 @@
+import "server-only";
+
+import { spotifyFetch } from "./client";
+
+type SpotifyTopTracksResponse = {
+  tracks: { id: string; name: string; preview_url: string | null }[];
+};
+
+// 아티스트 top-tracks 중 첫 번째 preview_url 반환 (없으면 null)
+export const getArtistPreviewUrl = async (
+  artistId: string,
+  market = "US"
+): Promise<string | null> => {
+  const data = await spotifyFetch<SpotifyTopTracksResponse>(
+    `/artists/${artistId}/top-tracks?market=${market}`
+  );
+
+  const trackWithPreview = data.tracks.find((track) => track.preview_url);
+  return trackWithPreview?.preview_url ?? null;
+};

--- a/src/lib/spotify/search.ts
+++ b/src/lib/spotify/search.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import type { MusicSelection } from "@/types/taste";
+
+import { spotifyFetch } from "./client";
+
+import type { SpotifySearchResponse } from "./types";
+
+const buildSearchPath = (query: string, type: "artist" | "track", limit: number) =>
+  `/search?q=${encodeURIComponent(query)}&type=${type}&limit=${limit}`;
+
+// 아티스트 검색 → MusicSelection 형태로 정규화 (store와 동일 타입)
+export const searchArtists = async (query: string, limit = 12): Promise<MusicSelection[]> => {
+  const data = await spotifyFetch<SpotifySearchResponse>(buildSearchPath(query, "artist", limit));
+
+  return (data.artists?.items ?? []).map((artist) => ({
+    id: artist.id,
+    name: artist.name,
+    image: artist.images[0]?.url ?? "",
+    genres: artist.genres,
+    previewUrl: null, // 아티스트엔 preview 없음 → #43에서 top-track으로 보강
+  }));
+};
+
+export type SpotifyTrackResult = {
+  id: string;
+  name: string;
+  artistName: string;
+  image: string;
+  previewUrl: string | null;
+};
+
+// 트랙 검색 → preview_url 포함
+export const searchTracks = async (query: string, limit = 12): Promise<SpotifyTrackResult[]> => {
+  const data = await spotifyFetch<SpotifySearchResponse>(buildSearchPath(query, "track", limit));
+
+  return (data.tracks?.items ?? []).map((track) => ({
+    id: track.id,
+    name: track.name,
+    artistName: track.artists.map((a) => a.name).join(", "),
+    image: track.album.images[0]?.url ?? "",
+    previewUrl: track.preview_url,
+  }));
+};

--- a/src/lib/spotify/types.ts
+++ b/src/lib/spotify/types.ts
@@ -1,0 +1,36 @@
+// Spotify Web API 응답 타입 — 검색 wrapper(search.ts)에서 사용
+
+export type SpotifyImage = {
+  url: string;
+  height: number | null;
+  width: number | null;
+};
+
+export type SpotifyArtist = {
+  id: string;
+  name: string;
+  images: SpotifyImage[];
+  genres: string[];
+};
+
+export type SpotifyTrack = {
+  id: string;
+  name: string;
+  artists: { id: string; name: string }[];
+  album: {
+    id: string;
+    name: string;
+    images: SpotifyImage[];
+  };
+  preview_url: string | null;
+};
+
+// /search 응답 — type 파라미터에 따라 artists / tracks 중 일부만 내려옴
+export type SpotifySearchResponse = {
+  artists?: {
+    items: SpotifyArtist[];
+  };
+  tracks?: {
+    items: SpotifyTrack[];
+  };
+};

--- a/src/lib/tmdb.ts
+++ b/src/lib/tmdb.ts
@@ -1,2 +1,0 @@
-// TODO: TMDB API 클라이언트
-export {};

--- a/src/lib/tmdb/client.ts
+++ b/src/lib/tmdb/client.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+const API_BASE = "https://api.themoviedb.org/3";
+
+const getApiKey = () => {
+  const apiKey = process.env.TMDB_API_KEY;
+  if (!apiKey) {
+    throw new Error("TMDB 환경변수 누락: TMDB_API_KEY 확인");
+  }
+  return apiKey;
+};
+
+// TMDB GET 요청 — api_key/언어 자동 주입 + 에러 처리
+export const tmdbFetch = async <T>(
+  endpoint: string,
+  params: Record<string, string> = {}
+): Promise<T> => {
+  const url = new URL(`${API_BASE}${endpoint}`);
+  url.searchParams.set("api_key", getApiKey());
+  url.searchParams.set("language", "ko-KR");
+
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  const res = await fetch(url, { cache: "no-store" });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`TMDB API 오류 (${res.status}): ${detail}`);
+  }
+
+  return res.json() as Promise<T>;
+};

--- a/src/lib/tmdb/image.ts
+++ b/src/lib/tmdb/image.ts
@@ -1,0 +1,19 @@
+const IMAGE_BASE = "https://image.tmdb.org/t/p";
+
+export type TmdbPosterSize = "w92" | "w154" | "w185" | "w342" | "w500" | "w780" | "original";
+export type TmdbBackdropSize = "w300" | "w780" | "w1280" | "original";
+
+// TMDB 경로("/abc.jpg") → 전체 이미지 URL. 경로 없으면 빈 문자열(fallback)
+export const getTmdbImageUrl = (
+  path: string | null | undefined,
+  size: TmdbPosterSize | TmdbBackdropSize = "w500"
+): string => {
+  if (!path) return "";
+  return `${IMAGE_BASE}/${size}${path}`;
+};
+
+export const getPosterUrl = (path: string | null | undefined, size: TmdbPosterSize = "w500") =>
+  getTmdbImageUrl(path, size);
+
+export const getBackdropUrl = (path: string | null | undefined, size: TmdbBackdropSize = "w1280") =>
+  getTmdbImageUrl(path, size);

--- a/src/lib/tmdb/search.ts
+++ b/src/lib/tmdb/search.ts
@@ -3,8 +3,10 @@ import "server-only";
 import type { MovieSelection } from "@/types/taste";
 
 import { tmdbFetch } from "./client";
+import { getBackdropUrl, getPosterUrl } from "./image";
 
 import type { TmdbGenreListResponse, TmdbSearchResponse } from "./types";
+
 
 // 장르 id→이름 맵 (모듈 캐시 — 매 검색마다 다시 안 부름)
 let genreMapCache: Map<number, string> | null = null;
@@ -30,8 +32,8 @@ export const searchMovies = async (query: string, limit = 12): Promise<MovieSele
   return data.results.slice(0, limit).map((movie) => ({
     id: movie.id,
     title: movie.title,
-    posterPath: movie.poster_path ?? "", // 경로만 — 전체 이미지 URL 변환은 #46
-    backdropPath: movie.backdrop_path ?? "",
+    posterPath: getPosterUrl(movie.poster_path),
+    backdropPath: getBackdropUrl(movie.backdrop_path),
     genres: movie.genre_ids
       .map((id) => genreMap.get(id))
       .filter((name): name is string => Boolean(name)),

--- a/src/lib/tmdb/search.ts
+++ b/src/lib/tmdb/search.ts
@@ -1,0 +1,40 @@
+import "server-only";
+
+import type { MovieSelection } from "@/types/taste";
+
+import { tmdbFetch } from "./client";
+
+import type { TmdbGenreListResponse, TmdbSearchResponse } from "./types";
+
+// 장르 id→이름 맵 (모듈 캐시 — 매 검색마다 다시 안 부름)
+let genreMapCache: Map<number, string> | null = null;
+
+const getGenreMap = async (): Promise<Map<number, string>> => {
+  if (genreMapCache) return genreMapCache;
+  const data = await tmdbFetch<TmdbGenreListResponse>("/genre/movie/list");
+  genreMapCache = new Map(data.genres.map((genre) => [genre.id, genre.name]));
+  return genreMapCache;
+};
+
+const getReleaseYear = (date: string): number => {
+  const year = Number(date?.slice(0, 4));
+  return Number.isFinite(year) ? year : 0;
+};
+
+export const searchMovies = async (query: string, limit = 12): Promise<MovieSelection[]> => {
+  const [data, genreMap] = await Promise.all([
+    tmdbFetch<TmdbSearchResponse>("/search/movie", { query, include_adult: "false" }),
+    getGenreMap(),
+  ]);
+
+  return data.results.slice(0, limit).map((movie) => ({
+    id: movie.id,
+    title: movie.title,
+    posterPath: movie.poster_path ?? "", // 경로만 — 전체 이미지 URL 변환은 #46
+    backdropPath: movie.backdrop_path ?? "",
+    genres: movie.genre_ids
+      .map((id) => genreMap.get(id))
+      .filter((name): name is string => Boolean(name)),
+    releaseYear: getReleaseYear(movie.release_date),
+  }));
+};

--- a/src/lib/tmdb/types.ts
+++ b/src/lib/tmdb/types.ts
@@ -1,0 +1,25 @@
+export type TmdbMovie = {
+  id: number;
+  title: string;
+  poster_path: string | null;
+  backdrop_path: string | null;
+  genre_ids: number[];
+  release_date: string; // "YYYY-MM-DD"
+  overview: string;
+};
+
+export type TmdbGenre = {
+  id: number;
+  name: string;
+};
+
+export type TmdbSearchResponse = {
+  page: number;
+  results: TmdbMovie[];
+  total_pages: number;
+  total_results: number;
+};
+
+export type TmdbGenreListResponse = {
+  genres: TmdbGenre[];
+};

--- a/src/store/tasteStore.ts
+++ b/src/store/tasteStore.ts
@@ -5,11 +5,14 @@ import type { Domain, MusicSelection, MovieSelection, FashionSelection } from "@
 
 type TasteStore = {
   selectedDomain: Domain | null;
+  // 1뎁스에서 고른 스타일/무드 (도메인별 — 도메인 간 영향 분리)
+  selectedStyles: Partial<Record<Domain, string>>;
   musicSelections: MusicSelection[];
   movieSelections: MovieSelection[];
   fashionSelections: FashionSelection[];
 
   setSelectedDomain: (domain: Domain) => void;
+  setSelectedStyle: (domain: Domain, styleId: string) => void;
   addMusicSelection: (item: MusicSelection) => void;
   removeMusicSelection: (id: string) => void;
   addMovieSelection: (item: MovieSelection) => void;
@@ -21,6 +24,7 @@ type TasteStore = {
 
 const initialState = {
   selectedDomain: null,
+  selectedStyles: {} as Partial<Record<Domain, string>>,
   musicSelections: [],
   movieSelections: [],
   fashionSelections: [{ styles: [], fashionMoods: [] }] as FashionSelection[],
@@ -32,6 +36,11 @@ export const useTasteStore = create<TasteStore>()(
       ...initialState,
 
       setSelectedDomain: (domain) => set({ selectedDomain: domain }),
+
+      setSelectedStyle: (domain, styleId) =>
+        set((state) => ({
+          selectedStyles: { ...state.selectedStyles, [domain]: styleId },
+        })),
 
       addMusicSelection: (item) =>
         set((state) => {
@@ -72,6 +81,6 @@ export const useTasteStore = create<TasteStore>()(
     {
       name: "taste-store",
       storage: createJSONStorage(() => sessionStorage),
-    },
-  ),
+    }
+  )
 );


### PR DESCRIPTION
## PR 제목

feat / ISSUE-27-taste-input-flow - taste 입력 플로우 1/2뎁스 구조 + Spotify/TMDB wrapper

## PR 본문

## 반영 브랜치
ISSUE-27-taste-input-flow → dev

## PR 타입
- [x] 기능 추가

## 작업 내용
### 취향 입력 플로우 구조 (#27 #28 #29 #30)
- TasteInputForm 공통 셸(헤더·검색·ProgressBar·BottomNav)로 2뎁스 UI 통일 (#27)
- 1뎁스: 스타일 셀렉션 리스트+프리뷰(StyleSelectList) — music/movie/fashion
- 2뎁스: TasteInputForm + 아티스트/영화 TasteCard 그리드 (music/movie)
- fashion: 2뎁스 없이 결과 직행 / store에 도메인별 selectedStyles 추가

### Spotify 연동 (#40 #41 #42 #43)
- client credentials 토큰 발급·캐싱(getSpotifyToken) + 공용 fetch(spotifyFetch)
- 아티스트/트랙 검색 wrapper + /api/spotify 라우트
- audio features 조회 wrapper (#42) — 코드 구현, Premium 제약으로 미검증
- ⚠️ Spotify Web API가 앱 소유 계정 Premium을 요구 → 무료 계정은 403. Premium 키 교체 시 동작
- preview URL fallback (#43) — 아티스트 top-tracks 첫 preview_url, Premium 제약으로 미검증

### TMDB 연동 (#44 #45 #46)
- tmdbFetch 클라이언트 / 영화 검색 wrapper + /api/tmdb 라우트 (장르 한글 매핑)
- 이미지 URL 변환 유틸 + next/image 도메인 설정

## 테스트 결과
- TMDB: `/api/tmdb?q=기생충` → 결과·이미지 정상
- Spotify: 토큰 발급 정상, 검색은 Premium 제약으로 403 (코드는 정상)

## 리뷰 대응
1. ✅ `src/lib/spotify/types.ts` 작성 — `SpotifySearchResponse`/`SpotifyArtist`/`SpotifyTrack` 정의, `tsc --noEmit` 통과 확인
2. 공용 컴포넌트(Card / SearchInput) 교체 — 머지 시 TODO 유지, 후속 대응
3. 2뎁스 ↔ Spotify/TMDB API 연동(MOCK 제거) — 별도 후속 이슈로 분리 트래킹 예정
4. FT-002 선택 개수별 안내 메시지 — 후속 이슈로 트래킹 예정
5. 로컬 500 — placeholder 키 이슈, 환경변수 공유 후 재확인
