### PR TITLE
feat / ISSUE-32-TasteInputCompletion - 취향 입력 완성 (검증·요약·버튼 상태)

### DIFF
--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -8,6 +8,7 @@ import { DomainGuard } from "@/components/domain/DomainGuard";
 import { MovieTasteCard } from "@/components/domain/movieTasteCard";
 import { MusicTasteCard } from "@/components/domain/musicTasteCard";
 import { TasteInputForm } from "@/components/domain/tasteInputForm";
+import { TasteSummary } from "@/components/domain/tasteSummary";
 import { getSelectionGuide } from "@/lib/taste/selectionGuide";
 import { useTasteStore } from "@/store/tasteStore";
 import type { Domain } from "@/types/taste";
@@ -74,9 +75,26 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const content = DETAIL_CONTENT[domain];
 
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+
   const handleAnalyze = () => {
-    // TODO: 실제 분석 API 응답의 resultId 사용
+    if (isAnalyzing) return; // 중복 클릭 방지
+    setIsAnalyzing(true);
+    // TODO(#35): 실제 분석 API 응답의 resultId 사용
     router.push("/result/mock-1");
+  };
+
+  // 선택 요약 (#33) — 도메인별 라벨 매핑
+  const summaryItems =
+    domain === "music"
+      ? musicSelections.map((s) => ({ id: s.id, label: s.name }))
+      : domain === "movie"
+        ? movieSelections.map((s) => ({ id: String(s.id), label: s.title }))
+        : [];
+
+  const handleRemoveSelection = (id: string) => {
+    if (domain === "music") removeMusicSelection(id);
+    else if (domain === "movie") removeMovieSelection(Number(id));
   };
 
   const handleSelectArtist = (artist: (typeof MOCK_ARTISTS)[number]) => {
@@ -122,6 +140,9 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
         isNextDisabled={!isComplete}
         onNext={handleAnalyze}
         guideMessage={message}
+        summary={<TasteSummary items={summaryItems} onRemove={handleRemoveSelection} />}
+        isNextLoading={isAnalyzing}
+        nextLoadingLabel="분석 중..."
       >
         {/* 2뎁스: TasteCard 그리드 */}
         <div className="grid-cols-responsive">

--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -8,6 +8,7 @@ import { DomainGuard } from "@/components/domain/DomainGuard";
 import { MovieTasteCard } from "@/components/domain/movieTasteCard";
 import { MusicTasteCard } from "@/components/domain/musicTasteCard";
 import { TasteInputForm } from "@/components/domain/tasteInputForm";
+import { getSelectionGuide } from "@/lib/taste/selectionGuide";
 import { useTasteStore } from "@/store/tasteStore";
 import type { Domain } from "@/types/taste";
 
@@ -64,13 +65,11 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
     if (domain === "fashion") router.replace("/taste/fashion");
   }, [domain, router]);
 
-  // 도메인별 선택 상태로 분기 (music/movie 영향 분리)
-  const isReady =
-    domain === "music"
-      ? musicSelections.length > 0
-      : domain === "movie"
-        ? movieSelections.length > 0
-        : false;
+  // 도메인별 선택 개수 (music/movie 영향 분리)
+  const selectionCount =
+    domain === "music" ? musicSelections.length : domain === "movie" ? movieSelections.length : 0;
+
+  const { isComplete, message } = getSelectionGuide(selectionCount);
 
   const [searchQuery, setSearchQuery] = useState("");
   const content = DETAIL_CONTENT[domain];
@@ -120,8 +119,9 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
         searchPlaceholder={content.searchPlaceholder}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
-        isNextDisabled={!isReady}
+        isNextDisabled={!isComplete}
         onNext={handleAnalyze}
+        guideMessage={message}
       >
         {/* 2뎁스: TasteCard 그리드 */}
         <div className="grid-cols-responsive">

--- a/src/components/domain/tasteInputForm/TasteInputForm.tsx
+++ b/src/components/domain/tasteInputForm/TasteInputForm.tsx
@@ -34,6 +34,9 @@ export function TasteInputForm({
   isNextDisabled,
   onNext,
   guideMessage,
+  summary,
+  isNextLoading,
+  nextLoadingLabel,
 }: ITasteInputFormProps) {
   return (
     <div className="page-container section-wrapper">
@@ -76,12 +79,13 @@ export function TasteInputForm({
           className="w-full rounded-full bg-white py-3 pl-12 pr-5 text-sm shadow-sm placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-500/30"
         />
       </div>
-
       {guideMessage && (
-        <p className="type-title-lg keep-all mt-4 mb-12 text-center text-primary-container">
+        <p className="type-title-lg keep-all mt-4 mb-6 text-center text-primary-container">
           {guideMessage}
         </p>
       )}
+
+      {summary}
 
       <section className="min-h-[60vh]">{children}</section>
 
@@ -91,6 +95,8 @@ export function TasteInputForm({
         nextLabel="스타일 분석 시작하기"
         isNextDisabled={isNextDisabled}
         onNext={onNext}
+        isLoading={isNextLoading}
+        loadingLabel={nextLoadingLabel}
         isLastStep
       />
     </div>

--- a/src/components/domain/tasteInputForm/TasteInputForm.tsx
+++ b/src/components/domain/tasteInputForm/TasteInputForm.tsx
@@ -33,6 +33,7 @@ export function TasteInputForm({
   children,
   isNextDisabled,
   onNext,
+  guideMessage,
 }: ITasteInputFormProps) {
   return (
     <div className="page-container section-wrapper">
@@ -75,6 +76,12 @@ export function TasteInputForm({
           className="w-full rounded-full bg-white py-3 pl-12 pr-5 text-sm shadow-sm placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-500/30"
         />
       </div>
+
+      {guideMessage && (
+        <p className="type-title-lg keep-all mt-4 mb-12 text-center text-primary-container">
+          {guideMessage}
+        </p>
+      )}
 
       <section className="min-h-[60vh]">{children}</section>
 

--- a/src/components/domain/tasteInputForm/tasteInputForm.types.ts
+++ b/src/components/domain/tasteInputForm/tasteInputForm.types.ts
@@ -15,4 +15,6 @@ export interface ITasteInputFormProps {
 
   isNextDisabled?: boolean;
   onNext?: () => void;
+
+  guideMessage?: string;
 }

--- a/src/components/domain/tasteInputForm/tasteInputForm.types.ts
+++ b/src/components/domain/tasteInputForm/tasteInputForm.types.ts
@@ -17,4 +17,12 @@ export interface ITasteInputFormProps {
   onNext?: () => void;
 
   guideMessage?: string;
+
+  /** 선택 요약 영역 (#33 TasteSummary 등) — guideMessage 아래 노출 */
+  summary?: ReactNode;
+
+  /** 분석 요청 진행 중 여부 (#34) — 버튼 로딩/비활성 처리 */
+  isNextLoading?: boolean;
+  /** 로딩 중 버튼 라벨 (기본: nextLabel 유지) */
+  nextLoadingLabel?: string;
 }

--- a/src/components/domain/tasteSummary/TasteSummary.tsx
+++ b/src/components/domain/tasteSummary/TasteSummary.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import type { ITasteSummaryProps } from "./tasteSummary.types";
+
+// ── TasteSummary ───────────────────────────────────────────────────────────────
+// 현재까지 선택한 취향을 한눈에 보여주는 요약 영역 (#33)
+// - 선택 개수 / 필요 개수 표시
+// - 각 항목을 칩으로 노출, 칩에서 바로 선택 해제 가능
+
+export const TasteSummary = ({ items, required = 3, onRemove, className }: ITasteSummaryProps) => {
+  return (
+    <section className={cn("mb-10 flex flex-col gap-3", className)} aria-label="선택한 취향 요약">
+      <div className="flex items-center gap-2">
+        <span className="type-title-sm text-on-background">선택한 취향</span>
+        <span className="type-label-md rounded-full bg-primary-container/10 px-2.5 py-0.5 text-primary-container">
+          {items.length}/{required}
+        </span>
+      </div>
+
+      {items.length === 0 ? (
+        <p className="type-body-md text-stone-400">아직 선택한 취향이 없어요</p>
+      ) : (
+        <ul className="flex flex-wrap gap-2">
+          {items.map((item) => (
+            <li key={item.id}>
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-primary-container/10 py-1.5 pl-3.5 pr-2 text-primary-container">
+                <span className="type-label-lg">{item.label}</span>
+
+                {onRemove && (
+                  <button
+                    type="button"
+                    onClick={() => onRemove(item.id)}
+                    aria-label={`${item.label} 선택 해제`}
+                    className="flex h-5 w-5 items-center justify-center rounded-full transition-colors hover:bg-primary-container/20"
+                  >
+                    <X size={14} />
+                  </button>
+                )}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};

--- a/src/components/domain/tasteSummary/index.ts
+++ b/src/components/domain/tasteSummary/index.ts
@@ -1,0 +1,2 @@
+export { TasteSummary } from "./TasteSummary";
+export type { ITasteSummaryProps, ITasteSummaryItem } from "./tasteSummary.types";

--- a/src/components/domain/tasteSummary/tasteSummary.types.ts
+++ b/src/components/domain/tasteSummary/tasteSummary.types.ts
@@ -1,0 +1,16 @@
+export interface ITasteSummaryItem {
+  /** 선택 항목 식별자 (music: string id, movie: 숫자 id를 문자열로 변환) */
+  id: string;
+  /** 칩에 표시될 라벨 (아티스트명 / 영화 제목) */
+  label: string;
+}
+
+export interface ITasteSummaryProps {
+  /** 현재 선택된 취향 목록 */
+  items: ITasteSummaryItem[];
+  /** 완성에 필요한 선택 개수 (기본 3) */
+  required?: number;
+  /** 칩의 해제 버튼 클릭 핸들러 — 없으면 해제 버튼 미노출 */
+  onRemove?: (id: string) => void;
+  className?: string;
+}

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -8,7 +8,7 @@
 
 import { useRouter } from "next/navigation";
 
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
@@ -20,6 +20,10 @@ type BottomNavProps = {
   isNextDisabled?: boolean;
   onNext?: () => void;
   isLastStep?: boolean;
+  /** 다음 액션 진행 중 여부 — 버튼 비활성 + 스피너 + 중복 클릭 방지 (#34) */
+  isLoading?: boolean;
+  /** 로딩 중 버튼 라벨 (미지정 시 nextLabel 유지) */
+  loadingLabel?: string;
 };
 
 export const BottomNav = ({
@@ -30,22 +34,33 @@ export const BottomNav = ({
   isNextDisabled = false,
   onNext,
   isLastStep = false,
+  isLoading = false,
+  loadingLabel,
 }: BottomNavProps) => {
   const router = useRouter();
 
   const handlePrev = () => {
+    if (isLoading) return;
     if (prevPath) router.push(prevPath);
     else router.back();
   };
 
   const handleNext = () => {
+    // 비활성 / 로딩 중 중복 실행 방지
+    if (isNextDisabled || isLoading) return;
     if (onNext) onNext();
     if (nextPath) router.push(nextPath);
   };
 
+  const nextIcon = isLoading ? (
+    <Loader2 size={16} className="animate-spin" />
+  ) : isLastStep ? (
+    <ArrowRight size={16} />
+  ) : undefined;
+
   return (
     <div className="flex items-center justify-between gap-4 py-6">
-      <Button variant="stroke" size="sm" onClick={handlePrev}>
+      <Button variant="stroke" size="sm" onClick={handlePrev} disabled={isLoading}>
         {prevLabel}
       </Button>
 
@@ -53,11 +68,12 @@ export const BottomNav = ({
         variant="primary"
         size="sm"
         onClick={handleNext}
-        disabled={isNextDisabled}
-        icon={isLastStep ? <ArrowRight size={16} /> : undefined}
+        disabled={isNextDisabled || isLoading}
+        aria-busy={isLoading}
+        icon={nextIcon}
         iconPosition="right"
       >
-        {nextLabel}
+        {isLoading ? (loadingLabel ?? nextLabel) : nextLabel}
       </Button>
     </div>
   );

--- a/src/lib/taste/selectionGuide.ts
+++ b/src/lib/taste/selectionGuide.ts
@@ -1,0 +1,27 @@
+export const REQUIRED_SELECTION = 3;
+
+export type SelectionGuide = {
+  isComplete: boolean;
+  message: string;
+};
+
+// 남은 개수별 안내 (진행감을 주는 카피)
+const REMAINING_MESSAGES: Record<number, string> = {
+  3: "마음이 가는 취향을 3개 골라주세요",
+  2: "좋아요! 2개만 더 골라볼까요?",
+  1: "거의 다 왔어요, 딱 하나만 더!",
+};
+
+// 선택 개수 → 버튼 활성 여부 + 안내 메시지 (FT-002)
+export const getSelectionGuide = (count: number, required = REQUIRED_SELECTION): SelectionGuide => {
+  const remaining = required - count;
+
+  if (remaining <= 0) {
+    return { isComplete: true, message: "취향이 완성됐어요! 분석을 시작할게요 ✨" };
+  }
+
+  return {
+    isComplete: false,
+    message: REMAINING_MESSAGES[remaining] ?? `${remaining}개 더 골라주세요`,
+  };
+};


### PR DESCRIPTION
### 반영 브랜치
ISSUE-32-TasteInputCompletion -> ISSUE-27-taste-input-flow

⚠️ base가 dev가 아니라 ISSUE-27인 이유

[#27](https://github.com/Style-Sync/stylesync/issues/27)이 아직 dev에 안 들어가 있어서, dev에 걸면 #27 커밋 12개까지 딸려옴. 
그래서 #27 위에 올림 → 이번 작업 [#32](https://github.com/Style-Sync/stylesync/issues/32) / [#33](https://github.com/Style-Sync/stylesync/issues/33) / [#34](https://github.com/Style-Sync/stylesync/issues/34) 2커밋만 깔끔하게 올라감. 
#27 dev 머지되면 dev로 rebase 예정.


### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용
- **#32 입력 검증 / 안내 메시지** (기존 반영분 포함): 선택 개수에 따라 버튼 활성 여부와 안내 카피 노출
- **#33 선택 취향 요약 컴포넌트(TasteSummary) 신규**: 선택 항목을 칩으로 표시, 카운트(n/3) 노출, 칩 X로 즉시 해제
- **#34 추론 요청 버튼 상태 처리**: 분석 요청 시 로딩 스피너 + 버튼 잠금으로 중복 클릭 방지

흐름: `tasteStore → detail/page.tsx → TasteSummary / TasteInputForm → BottomNav`
- page.tsx가 store 데이터를 읽어 요약 목록·로딩 상태를 내려주는 허브 역할
- TasteInputForm은 요약을 자리에 끼우고 로딩 값을 BottomNav로 전달
- BottomNav가 실제 버튼 로딩/잠금 처리

### 테스트 결과 (선택)
- lint / 타입체크 통과 확인 후 머지 예정
- 동작: 음악·영화 2뎁스에서 3개 선택 시 요약 칩 + 버튼 활성 → '분석 시작' 클릭 시 로딩 표시 후 결과 페이지 이동(현재 mock)

### 스크린샷 (선택)
<!-- 요약 칩 / 로딩 버튼 캡처 첨부 -->

### 리뷰 요구사항(선택)
- TasteSummary가 movie id(number)를 칩에선 String, 제거 시 Number로 변환하는데, store 타입과 더 깔끔하게 맞출 방법이 있을지 봐주세요
- 요약 영역 노출 위치(안내 메시지 아래)가 적절한지 UX 관점 피드백 부탁드립니다