### PR TITLE
feat / ISSUE-48-UnsplashApi - Unsplash 패션 이미지 검색 연동 (#48 #49 #50)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
       { protocol: "https", hostname: "placehold.co" }, // 목 추론 응답 이미지 (#35, 실제 API 연동 시 제거)
       { protocol: "https", hostname: "image.tmdb.org" }, // TMDB 포스터 (#78)
       { protocol: "https", hostname: "i.scdn.co" }, // Spotify 앨범 커버
+      { protocol: "https", hostname: "images.unsplash.com" }, // Unsplash 패션 이미지
     ],
   },
 };

--- a/public/fashion-placeholder.svg
+++ b/public/fashion-placeholder.svg
@@ -1,0 +1,9 @@
+﻿<svg xmlns="http://www.w3.org/2000/svg" width="400" height="600" viewBox="0 0 400 600">
+  <rect width="400" height="600" fill="#1c1b1a"/>
+  <g fill="none" stroke="#6b6660" stroke-width="2">
+    <rect x="150" y="250" width="100" height="100" rx="8"/>
+    <path d="M168 320l22-26 18 20 14-16 20 22" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="178" cy="278" r="8"/>
+  </g>
+  <text x="200" y="392" fill="#6b6660" font-family="sans-serif" font-size="16" text-anchor="middle">이미지 없음</text>
+</svg>

--- a/src/app/api/unsplash/route.ts
+++ b/src/app/api/unsplash/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { searchFashionImages } from "@/lib/unsplash/search";
+
+// GET /api/unsplash?q=street fashion
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const query = searchParams.get("q")?.trim();
+
+  if (!query) {
+    return NextResponse.json({ message: "검색어(q)가 필요합니다." }, { status: 400 });
+  }
+
+  try {
+    const results = await searchFashionImages(query);
+    return NextResponse.json({ results });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unsplash 검색 실패";
+    return NextResponse.json({ message }, { status: 500 });
+  }
+}

--- a/src/lib/unsplash/client.ts
+++ b/src/lib/unsplash/client.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+const API_BASE = "https://api.unsplash.com";
+
+const getAccessKey = () => {
+  const key = process.env.UNSPLASH_ACCESS_KEY;
+  if (!key) {
+    throw new Error("Unsplash 환경변수 누락: UNSPLASH_ACCESS_KEY 확인");
+  }
+  return key;
+};
+
+// 공용 fetch 래퍼 — Unsplash는 Access Key 헤더 인증 (OAuth 불필요)
+export const unsplashFetch = async <T>(endpoint: string, init?: RequestInit): Promise<T> => {
+  const accessKey = getAccessKey();
+
+  const res = await fetch(`${API_BASE}${endpoint}`, {
+    ...init,
+    headers: {
+      Authorization: `Client-ID ${accessKey}`,
+      "Accept-Version": "v1",
+      ...init?.headers,
+    },
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(`Unsplash API 오류 (${res.status}): ${detail}`);
+  }
+
+  return res.json() as Promise<T>;
+};

--- a/src/lib/unsplash/image.ts
+++ b/src/lib/unsplash/image.ts
@@ -1,0 +1,21 @@
+import type { FashionImage } from "./types";
+
+// public/ 에 두는 로컬 placeholder
+export const FASHION_PLACEHOLDER_URL = "/fashion-placeholder.svg";
+
+export const FASHION_PLACEHOLDER_IMAGE: FashionImage = {
+  id: "fashion-placeholder",
+  url: FASHION_PLACEHOLDER_URL,
+  thumbUrl: FASHION_PLACEHOLDER_URL,
+  alt: "이미지를 불러오지 못했어요",
+  authorName: "",
+  authorUrl: "",
+};
+
+// 검색 결과가 비면 placeholder 1장으로 대체 (#50)
+export const withFashionFallback = (images: FashionImage[]): FashionImage[] =>
+  images.length > 0 ? images : [FASHION_PLACEHOLDER_IMAGE];
+
+// 단일 이미지 URL fallback (깨진/빈 src 대비, 컴포넌트에서 사용)
+export const getFashionImageUrl = (url: string | null | undefined): string =>
+  url && url.length > 0 ? url : FASHION_PLACEHOLDER_URL;

--- a/src/lib/unsplash/search.ts
+++ b/src/lib/unsplash/search.ts
@@ -1,0 +1,28 @@
+import "server-only";
+
+import { unsplashFetch } from "./client";
+import { withFashionFallback } from "./image";
+
+import type { FashionImage, UnsplashSearchResponse } from "./types";
+
+const buildSearchPath = (query: string, perPage: number) =>
+  `/search/photos?query=${encodeURIComponent(query)}&per_page=${perPage}&orientation=portrait&content_filter=high`;
+
+const normalize = (res: UnsplashSearchResponse): FashionImage[] =>
+  res.results.map((photo) => ({
+    id: photo.id,
+    url: photo.urls.regular,
+    thumbUrl: photo.urls.small,
+    alt: photo.alt_description ?? photo.description ?? "fashion image",
+    authorName: photo.user.name,
+    authorUrl: photo.user.links.html,
+  }));
+
+// 패션 키워드로 이미지 검색 → 정규화 + 빈 결과 fallback 보장 (#49 + #50)
+export const searchFashionImages = async (
+  keyword: string,
+  perPage = 12
+): Promise<FashionImage[]> => {
+  const data = await unsplashFetch<UnsplashSearchResponse>(buildSearchPath(keyword, perPage));
+  return withFashionFallback(normalize(data));
+};

--- a/src/lib/unsplash/types.ts
+++ b/src/lib/unsplash/types.ts
@@ -1,0 +1,25 @@
+// ── Unsplash 원본 응답 (필요한 필드만) ──────────────────────────────
+export type UnsplashPhoto = {
+  id: string;
+  description: string | null;
+  alt_description: string | null;
+  urls: { raw: string; full: string; regular: string; small: string; thumb: string };
+  user: { name: string; links: { html: string } };
+  links: { html: string };
+};
+
+export type UnsplashSearchResponse = {
+  total: number;
+  total_pages: number;
+  results: UnsplashPhoto[];
+};
+
+// ── 앱 내부에서 쓰는 정규화 타입 ────────────────────────────────────
+export type FashionImage = {
+  id: string;
+  url: string; // 카드/배경용 (regular)
+  thumbUrl: string; // 썸네일 (small)
+  alt: string;
+  authorName: string;
+  authorUrl: string;
+};


### PR DESCRIPTION
### 반영 브랜치
ISSUE-48-UnsplashApi -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용
- **#48** Unsplash API 클라이언트(`unsplashFetch`) 구현 — Access Key 헤더 인증, 에러 처리. Spotify/TMDB와 동일한 client 패턴
- **#49** 패션 키워드 이미지 검색 wrapper(`searchFashionImages`) — `/search/photos` 호출 후 `FashionImage` 형태로 정규화 + `GET /api/unsplash` 라우트
- **#50** 이미지 fallback 처리 — 검색 결과가 없거나 src가 비면 로컬 placeholder로 대체
- 환경/빌드: `.env`에 `UNSPLASH_ACCESS_KEY` 사용, `next.config`에 `images.unsplash.com` 도메인 등록, `public/fashion-placeholder.svg` 추가

흐름: `/api/unsplash → search → client → Unsplash`, 결과 비면 `image`가 placeholder로 막음

### 테스트 결과 (선택)
- `npm run lint` / 타입체크 통과
- `GET /api/unsplash?q=street fashion` → FashionImage 배열 응답 확인
- 결과 없는 키워드 → placeholder 1장 반환 확인

### 스크린샷 (선택)
<!-- API 응답 / placeholder 노출 캡처 -->

### 리뷰 요구사항(선택)
- API 에러 시 route를 500으로 뒀는데(빈 결과는 wrapper가 placeholder로 처리), 에러 때도 placeholder를 내려주는 게 나을지 의견 부탁드려요
- `FashionImage` 정규화 필드(url/thumbUrl/alt/author)가 실제 사용처에 충분한지 봐주세요
- 검색 기본값(`per_page=12`, `orientation=portrait`, `content_filter=high`)이 적절한지 확인 부탁드립니다

Closes #48
Closes #49
Closes #50