### PR TITLE
feat / ISSUE-35-InferenceConnection - 추론 요청 정규화 및 /api/inference 연결 (#35 #47)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    images: {
-      remotePatterns: [
-        { protocol: "https", hostname: "image.tmdb.org" }, // TMDB 포스터/배경
-        { protocol: "https", hostname: "i.scdn.co" }, // Spotify 아티스트/앨범 (Premium 풀리면)
-      ],
-    },
-  };
-  
-  export default nextConfig;
+  images: {
+    remotePatterns: [
+      { protocol: "https", hostname: "placehold.co" }, // 목 추론 응답 이미지 (#35, 실제 API 연동 시 제거)
+    ],
+  },
+};
+
+export default nextConfig;

--- a/src/app/api/inference/route.ts
+++ b/src/app/api/inference/route.ts
@@ -1,6 +1,32 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export async function POST(_req: NextRequest) {
-  // TODO: AI 크로스 추론 로직
-  return NextResponse.json({ message: "not implemented" }, { status: 501 });
+import { getMockByDomain } from "@/lib/inference/inference.mocks";
+import { safeParseRequest, safeParseResponse } from "@/lib/inference/inference.schema";
+import type { InferenceResult } from "@/lib/inference/inference.types";
+
+// POST /api/inference — 요청 검증 → (현재) 도메인별 목 응답 반환
+// TODO(#58): 실제 Grok 호출로 교체
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+
+  const parsedReq = safeParseRequest(body);
+  if (!parsedReq.success) {
+    const message = parsedReq.error.issues[0]?.message ?? "요청 형식이 올바르지 않습니다.";
+    return NextResponse.json({ message }, { status: 400 });
+  }
+
+  const mock = getMockByDomain(parsedReq.data.domain);
+
+  const parsedRes = safeParseResponse(mock);
+  if (!parsedRes.success) {
+    return NextResponse.json({ message: "추론 응답 검증에 실패했습니다." }, { status: 500 });
+  }
+
+  const result: InferenceResult = {
+    ...parsedRes.data,
+    id: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
+  };
+
+  return NextResponse.json({ result });
 }

--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import { RecommendCard } from "@/components/result/recommendCard";
 import { ResultPageError } from "@/components/result/ResultPageError";
-import { ResultPageSkeleton } from "@/components/result/ResultPageSkeleton";
 import { ShareCard } from "@/components/result/shareCard";
 import { StyleLabelHero } from "@/components/result/styleLabel";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/Icon";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
-import type { StyleResult } from "@/types/result";
+import { useResultStore } from "@/store/resultStore";
 
 // X(Twitter) 아이콘 — Icon 레지스트리에 없어서 인라인 처리
 const XIcon = () => (
@@ -19,46 +18,13 @@ const XIcon = () => (
   </svg>
 );
 
-// ── Mock data (shell 단계 — 실제 API 연동 시 제거) ───────────────────────────
-const MOCK_RESULT: StyleResult = {
-  id: "mock-1",
-  styleLabel: {
-    title: "Melancholic Softboy",
-    description:
-      "향수 어린 빈티지 미학과 현대적인 감수성이 정교하게 어우러진 스타일입니다. 차분한 어스 톤과 오버사이즈 실루엣이 당신의 정체성을 정의합니다.",
-    themeColor: "#e6e6fa",
-    mood: { energy: "low", tone: "dark", aesthetic: "indie" },
-  },
-  music: [
-    { id: "1", name: "Blonde", artist: "Frank Ocean", image: "", previewUrl: null },
-    { id: "2", name: "Ivy", artist: "Frank Ocean", image: "", previewUrl: null },
-    { id: "3", name: "Nights", artist: "Frank Ocean", image: "", previewUrl: null },
-  ],
-  movie: [
-    { id: 1, title: "Call Me By Your Name", posterPath: "", genres: ["Drama", "Romance"] },
-    { id: 2, title: "Moonlight", posterPath: "", genres: ["Drama"] },
-    { id: 3, title: "Lost in Translation", posterPath: "", genres: ["Drama"] },
-  ],
-  fashion: [
-    { keyword: "Oversized Earth Tone Coat", image: "" },
-    { keyword: "Minimal Monochrome Set", image: "" },
-    { keyword: "Soft Denim Layer", image: "" },
-  ],
-  createdAt: new Date().toISOString(),
-};
-
-// ─────────────────────────────────────────────────────────────────────────────
-
 interface IResultPageProps {
   params: { id: string };
 }
 
-export default function ResultPage({ params: _params }: IResultPageProps) {
-  // TODO: _params.id로 API에서 실제 데이터 fetch
-  const [isLoading] = useState(false);
-  const [error] = useState<string | null>(null);
+export default function ResultPage({ params }: IResultPageProps) {
+  const result = useResultStore((s) => s.results[params.id]);
 
-  const { styleLabel, music, movie, fashion } = MOCK_RESULT;
   const { playingUrl, isPlaying: isAudioPlaying, toggle } = useAudioPlayer();
 
   const handleReanalyze = useCallback(() => {
@@ -69,8 +35,11 @@ export default function ResultPage({ params: _params }: IResultPageProps) {
     // TODO: 공유 카드 모달 연결
   }, []);
 
-  if (isLoading) return <ResultPageSkeleton />;
-  if (error) return <ResultPageError message={error} />;
+  if (!result) {
+    return <ResultPageError message="결과를 찾을 수 없어요. 다시 분석해 주세요." />;
+  }
+
+  const { styleLabel, music, movie, fashion } = result;
 
   return (
     <div className="bg-background">

--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -8,6 +8,9 @@ import { DomainGuard } from "@/components/domain/DomainGuard";
 import { MovieTasteCard } from "@/components/domain/movieTasteCard";
 import { MusicTasteCard } from "@/components/domain/musicTasteCard";
 import { TasteInputForm } from "@/components/domain/tasteInputForm";
+import { useInference } from "@/hooks/useInference";
+import { buildInferenceRequest } from "@/lib/inference/normalizeRequest";
+import { useResultStore } from "@/store/resultStore";
 import { useTasteStore } from "@/store/tasteStore";
 import type { Domain } from "@/types/taste";
 
@@ -58,6 +61,10 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
   const removeMusicSelection = useTasteStore((s) => s.removeMusicSelection);
   const addMovieSelection = useTasteStore((s) => s.addMovieSelection);
   const removeMovieSelection = useTasteStore((s) => s.removeMovieSelection);
+  const fashionSelections = useTasteStore((s) => s.fashionSelections);
+  const selectedStyles = useTasteStore((s) => s.selectedStyles);
+  const saveResult = useResultStore((s) => s.saveResult);
+  const { infer, isLoading: isAnalyzing } = useInference();
 
   // fashion은 2뎁스 미사용 → 1뎁스로 되돌림 (렌더 중 호출 X, useEffect)
   useEffect(() => {
@@ -75,9 +82,23 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const content = DETAIL_CONTENT[domain];
 
-  const handleAnalyze = () => {
-    // TODO: 실제 분석 API 응답의 resultId 사용
-    router.push("/result/mock-1");
+  const handleAnalyze = async () => {
+    try {
+      const request = buildInferenceRequest({
+        domain,
+        musicSelections,
+        movieSelections,
+        fashionSelections,
+        selectedStyles,
+      });
+      const result = await infer(request);
+      saveResult(result);
+      router.push(`/result/${result.id}`);
+    } catch (e) {
+      // 정규화 실패(예: 3개 미만) 또는 API 실패
+      console.error(e);
+      alert(e instanceof Error ? e.message : "분석에 실패했습니다.");
+    }
   };
 
   const handleSelectArtist = (artist: (typeof MOCK_ARTISTS)[number]) => {
@@ -120,7 +141,7 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
         searchPlaceholder={content.searchPlaceholder}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
-        isNextDisabled={!isReady}
+        isNextDisabled={!isReady || isAnalyzing}
         onNext={handleAnalyze}
       >
         {/* 2뎁스: TasteCard 그리드 */}

--- a/src/hooks/useInference.ts
+++ b/src/hooks/useInference.ts
@@ -1,4 +1,39 @@
-// TODO: AI 추론 훅
-export function useInference() {
-  return {};
+"use client";
+
+import { useState } from "react";
+
+import type { InferenceRequest, InferenceResult } from "@/lib/inference/inference.types";
+
+type UseInference = {
+  infer: (request: InferenceRequest) => Promise<InferenceResult>;
+  isLoading: boolean;
+  error: string | null;
+};
+
+export function useInference(): UseInference {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const infer = async (request: InferenceRequest): Promise<InferenceResult> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/inference", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(request),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.message ?? "추론 요청에 실패했습니다.");
+      return data.result as InferenceResult;
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "추론 요청에 실패했습니다.";
+      setError(message);
+      throw e;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { infer, isLoading, error };
 }

--- a/src/lib/inference/normalizeRequest.ts
+++ b/src/lib/inference/normalizeRequest.ts
@@ -1,0 +1,65 @@
+import type { Domain, FashionSelection, MovieSelection, MusicSelection } from "@/types/taste";
+
+import { safeParseRequest } from "./inference.schema";
+
+import type { InferenceRequest } from "./inference.types";
+
+type BuildArgs = {
+  domain: Domain;
+  musicSelections: MusicSelection[];
+  movieSelections: MovieSelection[];
+  fashionSelections: FashionSelection[];
+  selectedStyles: Partial<Record<Domain, string>>;
+};
+
+// TMDB 전체 URL("https://image.tmdb.org/t/p/w500/abc.jpg") 또는 빈 값을
+// 스키마가 요구하는 원본 경로("/abc.jpg")로 되돌림 (#47, posterPath 정규화)
+const toTmdbPath = (value: string): string => {
+  if (!value) return "/placeholder.jpg"; // 빈 값 → 검증 통과용 placeholder
+  if (value.startsWith("/")) return value; // 이미 원본 경로
+  const match = value.match(/\/t\/p\/[^/]+(\/.+)$/); // 전체 URL → 경로 추출
+  return match?.[1] ?? "/placeholder.jpg";
+};
+
+const normalizeMovies = (movies: MovieSelection[]): MovieSelection[] =>
+  movies.map((m) => ({
+    ...m,
+    posterPath: toTmdbPath(m.posterPath),
+    backdropPath: toTmdbPath(m.backdropPath),
+  }));
+
+// store 상태 → InferenceRequest 정규화 + zod 검증 (#47)
+export const buildInferenceRequest = (args: BuildArgs): InferenceRequest => {
+  const { domain, selectedStyles } = args;
+
+  let candidate: InferenceRequest;
+
+  if (domain === "music") {
+    candidate = {
+      domain: "music",
+      selections: args.musicSelections,
+      moods: selectedStyles.music ? [selectedStyles.music] : [],
+    };
+  } else if (domain === "movie") {
+    candidate = {
+      domain: "movie",
+      selections: normalizeMovies(args.movieSelections),
+      moods: selectedStyles.movie ? [selectedStyles.movie] : [],
+    };
+  } else {
+    const fashion = args.fashionSelections[0] ?? { styles: [], fashionMoods: [] };
+    candidate = {
+      domain: "fashion",
+      selections: args.fashionSelections,
+      moods: fashion.fashionMoods,
+    };
+  }
+
+  const parsed = safeParseRequest(candidate);
+  if (!parsed.success) {
+    const first = parsed.error.issues[0]?.message ?? "추론 요청 데이터가 유효하지 않습니다";
+    throw new Error(first);
+  }
+
+  return parsed.data;
+};

--- a/src/store/resultStore.ts
+++ b/src/store/resultStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+import type { StyleResult } from "@/types/result";
+
+type ResultStore = {
+  results: Record<string, StyleResult>;
+  saveResult: (result: StyleResult) => void;
+  getResult: (id: string) => StyleResult | undefined;
+};
+
+export const useResultStore = create<ResultStore>()(
+  persist(
+    (set, get) => ({
+      results: {},
+      saveResult: (result) =>
+        set((state) => ({ results: { ...state.results, [result.id]: result } })),
+      getResult: (id) => get().results[id],
+    }),
+    {
+      name: "result-store",
+      storage: createJSONStorage(() => sessionStorage),
+    }
+  )
+);


### PR DESCRIPTION
### 반영 브랜치
ISSUE-35-InferenceConnection -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용
- **#47 추론 요청 payload 정규화** — store(취향 선택 + 무드)를 `InferenceRequest` 형태로 변환·zod 검증하는 `buildInferenceRequest` 구현. TMDB posterPath는 원본 경로로 되돌려 스키마 충족
- **#35 /api/inference 호출 연결** — 화면에서 정규화된 요청으로 추론을 호출하고 결과를 받아 결과 페이지로 연결
  - `POST /api/inference`: 요청 검증 → 도메인별 목 응답 반환 (실제 Grok 호출은 후속 #58)
  - `useInference` 훅: API POST + 로딩/에러 상태
  - 결과 저장용 `resultStore`(zustand) 추가, `result/[id]` 페이지가 목 대신 store에서 결과 조회
  - 빌드: 목 이미지 호스트(`placehold.co`) `next.config` 등록 (실제 API 연동 시 제거)

흐름: `정규화(#47) → useInference POST → /api/inference 목 검증·반환 → resultStore 저장 → /result/[id] 이동`

### 테스트 결과 (선택)
- `npm run lint` / 타입체크 통과
- 음악·영화 취향 3개 선택 → "스타일 분석 시작하기" → 결과 페이지 정상 렌더 확인
- 3개 미만 선택 시 정규화 검증 실패 메시지 노출 확인

### 스크린샷 (선택)
<!-- 분석 → 결과 페이지 이동 캡처 -->

### 리뷰 요구사항(선택)
- 무드(moods) 출처를 `selectedStyles[domain]`(음악·영화) / `fashionMoods`(패션)로 잡았는데, 의도와 맞는지 확인 부탁드려요
- posterPath를 정규화 단계에서 원본 경로로 되돌리는 방식(빈 값은 placeholder 경로)이 적절한지 봐주세요
- 결과 저장을 sessionStorage 기반 `resultStore`로 했는데, 새로고침/직접 진입 시 정책(없으면 에러 페이지)이 괜찮은지 의견 부탁드립니다

Closes #35
Closes #47