### PR TITLE
fix / SS-43-iTunesPreview - Spotify preview_url → iTunes Search API 대체 (#43)

### DIFF
--- a/src/lib/spotify/preview.ts
+++ b/src/lib/spotify/preview.ts
@@ -1,20 +1,21 @@
 import "server-only";
 
-import { spotifyFetch } from "./client";
-
-type SpotifyTopTracksResponse = {
-  tracks: { id: string; name: string; preview_url: string | null }[];
+type ItunesSearchResponse = {
+  results: { previewUrl?: string }[];
 };
 
-// 아티스트 top-tracks 중 첫 번째 preview_url 반환 (없으면 null)
 export const getArtistPreviewUrl = async (
-  artistId: string,
-  market = "US"
+  artistName: string,
+  country = "KR"
 ): Promise<string | null> => {
-  const data = await spotifyFetch<SpotifyTopTracksResponse>(
-    `/artists/${artistId}/top-tracks?market=${market}`
-  );
+  const url = `https://itunes.apple.com/search?term=${encodeURIComponent(artistName)}&entity=song&limit=5&country=${country}`;
 
-  const trackWithPreview = data.tracks.find((track) => track.preview_url);
-  return trackWithPreview?.preview_url ?? null;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data: ItunesSearchResponse = await res.json();
+    return data.results.find((r) => r.previewUrl)?.previewUrl ?? null;
+  } catch {
+    return null;
+  }
 };

--- a/src/lib/spotify/search.ts
+++ b/src/lib/spotify/search.ts
@@ -3,23 +3,27 @@ import "server-only";
 import type { MusicSelection } from "@/types/taste";
 
 import { spotifyFetch } from "./client";
+import { getArtistPreviewUrl } from "./preview";
 
 import type { SpotifySearchResponse } from "./types";
 
 const buildSearchPath = (query: string, type: "artist" | "track", limit: number) =>
   `/search?q=${encodeURIComponent(query)}&type=${type}&limit=${limit}`;
 
-// 아티스트 검색 → MusicSelection 형태로 정규화 (store와 동일 타입)
+// 아티스트 검색 → MusicSelection 형태로 정규화. iTunes API로 previewUrl 보강
 export const searchArtists = async (query: string, limit = 12): Promise<MusicSelection[]> => {
   const data = await spotifyFetch<SpotifySearchResponse>(buildSearchPath(query, "artist", limit));
+  const artists = data.artists?.items ?? [];
 
-  return (data.artists?.items ?? []).map((artist) => ({
-    id: artist.id,
-    name: artist.name,
-    image: artist.images[0]?.url ?? "",
-    genres: artist.genres,
-    previewUrl: null, // 아티스트엔 preview 없음 → #43에서 top-track으로 보강
-  }));
+  return Promise.all(
+    artists.map(async (artist) => ({
+      id: artist.id,
+      name: artist.name,
+      image: artist.images[0]?.url ?? "",
+      genres: artist.genres,
+      previewUrl: await getArtistPreviewUrl(artist.name),
+    }))
+  );
 };
 
 export type SpotifyTrackResult = {


### PR DESCRIPTION
## Summary

Spotify가 2024-11-27부터 신규 등록 앱의 `preview_url`을 영구 `null`로 반환하는 정책에 대응. hoon730 #43 코멘트의 iTunes Search API 대체안을 구현.

**변경 파일**
- `src/lib/spotify/preview.ts` — `getArtistPreviewUrl` 내부를 iTunes Search API 호출로 교체 (함수명·반환 타입 유지)
  - 인증 불필요, 무료, `country=KR` 지원, 30초 m4a `previewUrl` 제공
- `src/lib/spotify/search.ts` — `searchArtists`에서 각 아티스트명으로 `getArtistPreviewUrl` 호출해 iTunes previewUrl 보강

**유지 (변경 없음)**
- `src/types/taste.ts` `MusicSelection.previewUrl` 필드
- `src/app/api/spotify/route.ts` 응답 구조
- `useAudioPlayer`, `RecommendCard` — URL만 수신하므로 영향 없음

closes #43

## Test plan

- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [ ] `GET /api/spotify?q=NewJeans` 호출 → 일부 트랙에 iTunes previewUrl 포함 확인
- [ ] K-pop 아티스트 커버리지 (`country=KR`) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)