### PR TITLE
feat / SS-78-MovieCardTmdbImage - 영화 카드 TMDB 이미지 + Spotify fallback (#78 #69 #76)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,6 +3,8 @@ const nextConfig = {
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "placehold.co" }, // 목 추론 응답 이미지 (#35, 실제 API 연동 시 제거)
+      { protocol: "https", hostname: "image.tmdb.org" }, // TMDB 포스터 (#78)
+      { protocol: "https", hostname: "i.scdn.co" }, // Spotify 앨범 커버
     ],
   },
 };

--- a/src/app/api/inference/route.ts
+++ b/src/app/api/inference/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { enrichResponseWithTmdb } from "@/lib/inference/enrichResponse";
 import { getMockByDomain } from "@/lib/inference/inference.mocks";
 import { safeParseRequest, safeParseResponse } from "@/lib/inference/inference.schema";
 import type { InferenceResult } from "@/lib/inference/inference.types";
@@ -22,8 +23,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ message: "추론 응답 검증에 실패했습니다." }, { status: 500 });
   }
 
+  // #78 — 영화 항목의 posterPath를 TMDB 검색으로 채움 (mock prefix 또는 빈 값 대상)
+  const enriched = await enrichResponseWithTmdb(parsedRes.data);
+
   const result: InferenceResult = {
-    ...parsedRes.data,
+    ...enriched,
     id: crypto.randomUUID(),
     createdAt: new Date().toISOString(),
   };

--- a/src/components/result/recommendCard/RecommendCard.tsx
+++ b/src/components/result/recommendCard/RecommendCard.tsx
@@ -65,31 +65,49 @@ const MusicCardContent = ({
         </div>
       </div>
 
-      {/* ── 30S PREVIEW 버튼 ─────────────────────────────────────────────── */}
+      {/* ── PREVIEW / Spotify fallback 버튼 ───────────────────────────────── */}
       <div className="px-5 pb-5 lg:px-10 lg:pb-10">
-        <button
-          type="button"
-          onClick={hasPreview ? onPreviewClick : undefined}
-          disabled={!hasPreview}
-          aria-label={hasPreview ? `${title} 30초 미리듣기` : "미리듣기를 사용할 수 없습니다"}
-          className={[
-            // rounded = DEFAULT = 1rem = 16px (design system token)
-            "w-full h-[33px] lg:h-[57px] rounded",
-            "flex items-center justify-center gap-3",
-            "font-korean font-medium text-body-sm text-on-background",
-            "transition-all duration-200",
-            hasPreview
-              ? "bg-surface hover:bg-surface/80 active:scale-[0.98]"
-              : "bg-surface/40 cursor-not-allowed opacity-50",
-          ].join(" ")}
-        >
-          {isPlaying ? (
-            <EqualizerBars size="sm" className="text-on-background" />
-          ) : (
+        {hasPreview ? (
+          <button
+            type="button"
+            onClick={onPreviewClick}
+            aria-label={`${title} 30초 미리듣기`}
+            className={[
+              "w-full h-[33px] lg:h-[57px] rounded",
+              "flex items-center justify-center gap-3",
+              "font-korean font-medium text-body-sm text-on-background",
+              "transition-all duration-200",
+              "bg-surface hover:bg-surface/80 active:scale-[0.98]",
+            ].join(" ")}
+          >
+            {isPlaying ? (
+              <EqualizerBars size="sm" className="text-on-background" />
+            ) : (
+              <Icon name="play" size={12} />
+            )}
+            <span className="tracking-widest uppercase">
+              {isPlaying ? "PLAYING" : "30S PREVIEW"}
+            </span>
+          </button>
+        ) : (
+          // #76 — iTunes preview 없을 시 Spotify 검색 페이지로 fallback (FT-002 명세)
+          <a
+            href={`https://open.spotify.com/search/${encodeURIComponent(`${subtitle ?? ""} ${title}`.trim())}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${title}을(를) Spotify에서 듣기`}
+            className={[
+              "w-full h-[33px] lg:h-[57px] rounded",
+              "flex items-center justify-center gap-3",
+              "font-korean font-medium text-body-sm text-on-background",
+              "transition-all duration-200",
+              "bg-surface hover:bg-surface/80 active:scale-[0.98]",
+            ].join(" ")}
+          >
             <Icon name="play" size={12} />
-          )}
-          <span className="tracking-widest uppercase">{isPlaying ? "PLAYING" : "30S PREVIEW"}</span>
-        </button>
+            <span className="tracking-widest uppercase">OPEN IN SPOTIFY</span>
+          </a>
+        )}
       </div>
     </>
   );

--- a/src/lib/inference/enrichResponse.ts
+++ b/src/lib/inference/enrichResponse.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { searchMovies } from "@/lib/tmdb/search";
+
+import type { InferenceResponse } from "./inference.types";
+
+// posterPath가 비어있거나 mock prefix("/mock/")로 시작하면 TMDB 검색 대상
+const needsTmdbEnrichment = (posterPath: string): boolean =>
+  !posterPath || posterPath.startsWith("/mock/");
+
+// 영화 제목으로 TMDB 검색 → 첫 결과의 posterPath (전체 URL) 반환
+const fetchMoviePoster = async (title: string): Promise<string> => {
+  try {
+    const results = await searchMovies(title, 1);
+    return results[0]?.posterPath ?? "";
+  } catch {
+    return "";
+  }
+};
+
+// Grok(또는 mock) 응답의 영화 항목에 TMDB 포스터 URL을 채워 넣음 (#78)
+export const enrichResponseWithTmdb = async (
+  response: InferenceResponse
+): Promise<InferenceResponse> => {
+  const enrichedMovies = await Promise.all(
+    response.movie.map(async (movie) => {
+      if (!needsTmdbEnrichment(movie.posterPath)) return movie;
+      const posterPath = await fetchMoviePoster(movie.title);
+      return posterPath ? { ...movie, posterPath } : movie;
+    })
+  );
+
+  return { ...response, movie: enrichedMovies };
+};


### PR DESCRIPTION
## 반영 브랜치

SS-78-MovieCardTmdbImage → dev

## PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용

Feature C Week 4 잔여 항목 3건을 한 PR로 마무리합니다.

### #78 TMDB 이미지 렌더링
- `src/lib/inference/enrichResponse.ts` 신설 — inference 응답의 영화 항목 `posterPath`가 비어있거나 `/mock/` prefix면 `searchMovies(title, 1)`로 TMDB 검색해 전체 URL로 채움
- `src/app/api/inference/route.ts` — mock 응답 zod 검증 통과 후 `enrichResponseWithTmdb` 호출 단계 추가
- `next.config.mjs` — `image.tmdb.org`, `i.scdn.co` 도메인 등록 (PR #225 머지 시 누락된 회귀 보정)

### #69 영화 추천 카드 연결
- 결과 페이지(`/result/[id]`)의 영화 카드 렌더는 PR #225 머지로 이미 완료된 상태
- 본 PR의 #78 enrichment로 TMDB 이미지가 자동으로 채워지면서 영화 카드 시각적 완성

### #76 Spotify fallback 버튼
- `src/components/result/recommendCard/RecommendCard.tsx` `MusicCardContent` — `previewUrl === null` 시 기존 비활성 \"30S PREVIEW\" 버튼 대신 \"OPEN IN SPOTIFY\" fallback 버튼 노출
- URL: `https://open.spotify.com/search/${encodeURIComponent(\`${artist} ${trackName}\`)}`
- `target=\"_blank\" rel=\"noopener noreferrer\"`로 새 탭 열기
- FT-002 / FT-004 명세 \"iTunes preview 없을 시 fallback: Spotify 앱 연결 버튼으로 대체\" 충족

### 명세 보강
- FT-004 명세에 음악 카드 인터랙션(iTunes 30초 샘플 + Spotify fallback) 항목 추가 (노션 반영 완료)

## 테스트 결과

- `npx tsc --noEmit` 통과
- 결과 페이지 동작 확인:
  - `Motion Sickness` (previewUrl null) 카드에서 \"OPEN IN SPOTIFY\" 버튼 노출 확인
  - `Cherry Wine` / `Moon Song` (previewUrl 있음) 카드에서 \"30S PREVIEW\" 버튼 정상 노출
- TMDB enrichment: `.env.local` API 키 placeholder 환경에선 fallthrough(기존 mock posterPath 유지), 실제 키 주입 시 TMDB 경로로 채워짐 확인

## 리뷰 요구사항

- enrichment 트리거 조건(`/mock/` prefix 또는 빈 값)이 적절한지, 추후 실제 Grok 응답에서도 빈 posterPath만 검사하면 충분할지 의견 부탁드려요
- Spotify 검색 URL을 `artist + trackName`으로 구성했는데, 정확도를 위해 다른 쿼리 조합(예: artist만, track ID 등)이 더 나을지 봐주세요

Closes #78
Closes #69
Closes #76