### PR TITLE
feat / SS-59-GrokRoute - Grok fetch 클라이언트 및 /api/inference route 배선

### DIFF
--- a/src/app/api/inference/route.ts
+++ b/src/app/api/inference/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { callGrok } from "@/lib/grok";
 import { enrichResponseWithTmdb } from "@/lib/inference/enrichResponse";
-import { getMockByDomain } from "@/lib/inference/inference.mocks";
+import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/inference/inference.prompts";
 import { safeParseRequest, safeParseResponse } from "@/lib/inference/inference.schema";
 import type { InferenceResult } from "@/lib/inference/inference.types";
 
-// POST /api/inference — 요청 검증 → (현재) 도메인별 목 응답 반환
-// TODO(#58): 실제 Grok 호출로 교체
 export async function POST(req: NextRequest) {
   const body = await req.json().catch(() => null);
 
@@ -16,14 +15,30 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ message }, { status: 400 });
   }
 
-  const mock = getMockByDomain(parsedReq.data.domain);
+  let raw: string;
+  try {
+    const userPrompt = buildUserPrompt(parsedReq.data);
+    raw = await callGrok([
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userPrompt },
+    ]);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Grok API 호출에 실패했습니다.";
+    return NextResponse.json({ message }, { status: 500 });
+  }
 
-  const parsedRes = safeParseResponse(mock);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return NextResponse.json({ message: "추론 응답 파싱에 실패했습니다." }, { status: 500 });
+  }
+
+  const parsedRes = safeParseResponse(parsed);
   if (!parsedRes.success) {
     return NextResponse.json({ message: "추론 응답 검증에 실패했습니다." }, { status: 500 });
   }
 
-  // #78 — 영화 항목의 posterPath를 TMDB 검색으로 채움 (mock prefix 또는 빈 값 대상)
   const enriched = await enrichResponseWithTmdb(parsedRes.data);
 
   const result: InferenceResult = {

--- a/src/lib/grok.ts
+++ b/src/lib/grok.ts
@@ -1,2 +1,36 @@
-// TODO: Grok AI 클라이언트 설정
-export {};
+import "server-only";
+
+const GROK_API_URL = "https://api.x.ai/v1/chat/completions";
+const GROK_MODEL = "grok-3";
+
+export type GrokMessage = {
+  role: "system" | "user" | "assistant";
+  content: string;
+};
+
+type GrokApiResponse = {
+  choices: { message: { content: string } }[];
+};
+
+export async function callGrok(messages: GrokMessage[]): Promise<string> {
+  const apiKey = process.env.GROK_API_KEY;
+  if (!apiKey) throw new Error("GROK_API_KEY 환경변수가 설정되지 않았습니다.");
+
+  const res = await fetch(GROK_API_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ model: GROK_MODEL, messages, temperature: 0.7 }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Grok API 오류: ${res.status} ${res.statusText}`);
+  }
+
+  const data: GrokApiResponse = await res.json();
+  const content = data.choices[0]?.message?.content;
+  if (!content) throw new Error("Grok 응답에 content가 없습니다.");
+  return content;
+}

--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -27,3 +27,6 @@ export {
 } from "./inference.mocks";
 
 export { SYSTEM_PROMPT, buildUserPrompt } from "./inference.prompts";
+
+export { callGrok } from "@/lib/grok";
+export type { GrokMessage } from "@/lib/grok";


### PR DESCRIPTION
## Summary

- `src/lib/grok.ts`: `callGrok(messages)` 구현 — native fetch, OpenAI-호환 엔드포인트(`https://api.x.ai/v1/chat/completions`), `GROK_API_KEY` 미설정 시 명확한 에러 throw
- `src/app/api/inference/route.ts`: mock 반환 제거 → `buildUserPrompt` + `SYSTEM_PROMPT`로 Grok 호출, `safeParseResponse` Zod 검증, `InferenceResult` 반환
- `src/lib/inference/index.ts`: `callGrok` / `GrokMessage` re-export 추가

closes #59

## Test plan
- [ ] `pnpm type-check` 통과
- [ ] `pnpm lint` 통과
- [ ] `GROK_API_KEY` 설정 후 `POST /api/inference`에 mock body 전송 → 200 + `InferenceResult` 반환
- [ ] body 누락/형식 오류 → 400 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)