### PR TITLE
feat / SS-60-OutputParsing - 방어적 JSON 추출 파서 구현

### DIFF
--- a/src/app/api/inference/route.ts
+++ b/src/app/api/inference/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { callGrok } from "@/lib/grok";
 import { enrichResponseWithTmdb } from "@/lib/inference/enrichResponse";
+import { parseInferenceResponse } from "@/lib/inference/inference.parser";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/inference/inference.prompts";
-import { safeParseRequest, safeParseResponse } from "@/lib/inference/inference.schema";
+import { safeParseRequest } from "@/lib/inference/inference.schema";
 import type { InferenceResult } from "@/lib/inference/inference.types";
 
 export async function POST(req: NextRequest) {
@@ -27,19 +28,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ message }, { status: 500 });
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return NextResponse.json({ message: "추론 응답 파싱에 실패했습니다." }, { status: 500 });
+  const parsed = parseInferenceResponse(raw);
+  if (!parsed.ok) {
+    return NextResponse.json({ message: parsed.message }, { status: 422 });
   }
 
-  const parsedRes = safeParseResponse(parsed);
-  if (!parsedRes.success) {
-    return NextResponse.json({ message: "추론 응답 검증에 실패했습니다." }, { status: 500 });
-  }
-
-  const enriched = await enrichResponseWithTmdb(parsedRes.data);
+  const enriched = await enrichResponseWithTmdb(parsed.data);
 
   const result: InferenceResult = {
     ...enriched,

--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -28,5 +28,7 @@ export {
 
 export { SYSTEM_PROMPT, buildUserPrompt } from "./inference.prompts";
 
+export { parseInferenceResponse } from "./inference.parser";
+
 export { callGrok } from "@/lib/grok";
 export type { GrokMessage } from "@/lib/grok";

--- a/src/lib/inference/inference.parser.ts
+++ b/src/lib/inference/inference.parser.ts
@@ -1,0 +1,40 @@
+import { safeParseResponse } from "./inference.schema";
+
+import type { InferenceResponse } from "./inference.types";
+
+function extractJson(raw: string): unknown {
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = fenced ? fenced[1].trim() : raw.trim();
+
+  const start = candidate.indexOf("{");
+  const end = candidate.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    throw new SyntaxError("JSON 객체를 찾을 수 없습니다.");
+  }
+
+  return JSON.parse(candidate.slice(start, end + 1));
+}
+
+type ParseSuccess = { ok: true; data: InferenceResponse };
+type ParseFailure = { ok: false; reason: "json" | "schema"; message: string };
+
+export function parseInferenceResponse(raw: string): ParseSuccess | ParseFailure {
+  let parsed: unknown;
+  try {
+    parsed = extractJson(raw);
+  } catch (e) {
+    return {
+      ok: false,
+      reason: "json",
+      message: e instanceof Error ? e.message : "JSON 파싱 실패",
+    };
+  }
+
+  const result = safeParseResponse(parsed);
+  if (!result.success) {
+    const message = result.error.issues[0]?.message ?? "응답 스키마 검증 실패";
+    return { ok: false, reason: "schema", message };
+  }
+
+  return { ok: true, data: result.data };
+}


### PR DESCRIPTION
## Summary

- `src/lib/inference/inference.parser.ts` 신규 생성:
  - `extractJson(raw)`: 코드블록 펜스(```json) 제거 → 첫 `{` ~ 마지막 `}` 슬라이스 → `JSON.parse`
  - `parseInferenceResponse(raw)`: `extractJson` + `safeParseResponse` 조합, `reason: "json" | "schema"` 분기 반환
- `route.ts`: 인라인 `JSON.parse` → `parseInferenceResponse`로 교체, 실패 시 422 반환
- `index.ts`: `parseInferenceResponse` re-export 추가

closes #60

## Test plan
- [ ] `pnpm type-check` 통과
- [ ] `pnpm lint` 통과
- [ ] 코드블록으로 감싼 응답 → 정상 파싱
- [ ] `}` 이후 후행 텍스트 → 정상 파싱
- [ ] 깨진 JSON → 422 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)