### PR TITLE
feat / SS-61-FailureTimeout - timeout 처리 및 에러 status 매핑

### DIFF
--- a/src/app/api/inference/route.ts
+++ b/src/app/api/inference/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { callGrok } from "@/lib/grok";
 import { enrichResponseWithTmdb } from "@/lib/inference/enrichResponse";
+import { parseInferenceResponse } from "@/lib/inference/inference.parser";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/inference/inference.prompts";
-import { safeParseRequest, safeParseResponse } from "@/lib/inference/inference.schema";
+import { safeParseRequest } from "@/lib/inference/inference.schema";
 import type { InferenceResult } from "@/lib/inference/inference.types";
 
 export async function POST(req: NextRequest) {
@@ -27,19 +28,12 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ message }, { status: 500 });
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return NextResponse.json({ message: "추론 응답 파싱에 실패했습니다." }, { status: 500 });
+  const parsed = parseInferenceResponse(raw);
+  if (!parsed.ok) {
+    return NextResponse.json({ message: parsed.message }, { status: 422 });
   }
 
-  const parsedRes = safeParseResponse(parsed);
-  if (!parsedRes.success) {
-    return NextResponse.json({ message: "추론 응답 검증에 실패했습니다." }, { status: 500 });
-  }
-
-  const enriched = await enrichResponseWithTmdb(parsedRes.data);
+  const enriched = await enrichResponseWithTmdb(parsed.data);
 
   const result: InferenceResult = {
     ...enriched,

--- a/src/app/api/inference/route.ts
+++ b/src/app/api/inference/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { callGrok } from "@/lib/grok";
+import { GrokApiError, GrokTimeoutError, callGrok } from "@/lib/grok";
 import { enrichResponseWithTmdb } from "@/lib/inference/enrichResponse";
 import { parseInferenceResponse } from "@/lib/inference/inference.parser";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/inference/inference.prompts";
@@ -24,8 +24,13 @@ export async function POST(req: NextRequest) {
       { role: "user", content: userPrompt },
     ]);
   } catch (e) {
-    const message = e instanceof Error ? e.message : "Grok API 호출에 실패했습니다.";
-    return NextResponse.json({ message }, { status: 500 });
+    if (e instanceof GrokTimeoutError) {
+      return NextResponse.json({ message: e.message }, { status: 504 });
+    }
+    if (e instanceof GrokApiError) {
+      return NextResponse.json({ message: e.message }, { status: 502 });
+    }
+    return NextResponse.json({ message: "추론 서비스 오류가 발생했습니다." }, { status: 500 });
   }
 
   const parsed = parseInferenceResponse(raw);

--- a/src/lib/grok.ts
+++ b/src/lib/grok.ts
@@ -30,10 +30,7 @@ export class GrokApiError extends Error {
   }
 }
 
-export async function callGrok(messages: GrokMessage[]): Promise<string> {
-  const apiKey = process.env.GROK_API_KEY;
-  if (!apiKey) throw new Error("GROK_API_KEY 환경변수가 설정되지 않았습니다.");
-
+async function fetchGrok(apiKey: string, messages: GrokMessage[]): Promise<string> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), GROK_TIMEOUT_MS);
 
@@ -61,4 +58,18 @@ export async function callGrok(messages: GrokMessage[]): Promise<string> {
   const content = data.choices[0]?.message?.content;
   if (!content) throw new Error("Grok 응답에 content가 없습니다.");
   return content;
+}
+
+export async function callGrok(messages: GrokMessage[]): Promise<string> {
+  const apiKey = process.env.GROK_API_KEY;
+  if (!apiKey) throw new Error("GROK_API_KEY 환경변수가 설정되지 않았습니다.");
+
+  try {
+    return await fetchGrok(apiKey, messages);
+  } catch (e) {
+    if (e instanceof GrokTimeoutError) {
+      return await fetchGrok(apiKey, messages);
+    }
+    throw e;
+  }
 }

--- a/src/lib/grok.ts
+++ b/src/lib/grok.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 const GROK_API_URL = "https://api.x.ai/v1/chat/completions";
 const GROK_MODEL = "grok-3";
+const GROK_TIMEOUT_MS = 30_000;
 
 export type GrokMessage = {
   role: "system" | "user" | "assistant";
@@ -12,22 +13,49 @@ type GrokApiResponse = {
   choices: { message: { content: string } }[];
 };
 
+export class GrokTimeoutError extends Error {
+  constructor() {
+    super("Grok API 응답 시간이 초과됐습니다.");
+    this.name = "GrokTimeoutError";
+  }
+}
+
+export class GrokApiError extends Error {
+  constructor(
+    public status: number,
+    statusText: string
+  ) {
+    super(`Grok API 오류: ${status} ${statusText}`);
+    this.name = "GrokApiError";
+  }
+}
+
 export async function callGrok(messages: GrokMessage[]): Promise<string> {
   const apiKey = process.env.GROK_API_KEY;
   if (!apiKey) throw new Error("GROK_API_KEY 환경변수가 설정되지 않았습니다.");
 
-  const res = await fetch(GROK_API_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({ model: GROK_MODEL, messages, temperature: 0.7 }),
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GROK_TIMEOUT_MS);
 
-  if (!res.ok) {
-    throw new Error(`Grok API 오류: ${res.status} ${res.statusText}`);
+  let res: Response;
+  try {
+    res = await fetch(GROK_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model: GROK_MODEL, messages, temperature: 0.7 }),
+      signal: controller.signal,
+    });
+  } catch (e) {
+    if (e instanceof Error && e.name === "AbortError") throw new GrokTimeoutError();
+    throw e;
+  } finally {
+    clearTimeout(timer);
   }
+
+  if (!res.ok) throw new GrokApiError(res.status, res.statusText);
 
   const data: GrokApiResponse = await res.json();
   const content = data.choices[0]?.message?.content;

--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -28,5 +28,7 @@ export {
 
 export { SYSTEM_PROMPT, buildUserPrompt } from "./inference.prompts";
 
+export { parseInferenceResponse } from "./inference.parser";
+
 export { callGrok } from "@/lib/grok";
 export type { GrokMessage } from "@/lib/grok";

--- a/src/lib/inference/inference.parser.ts
+++ b/src/lib/inference/inference.parser.ts
@@ -1,0 +1,40 @@
+import { safeParseResponse } from "./inference.schema";
+
+import type { InferenceResponse } from "./inference.types";
+
+function extractJson(raw: string): unknown {
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = fenced ? fenced[1].trim() : raw.trim();
+
+  const start = candidate.indexOf("{");
+  const end = candidate.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) {
+    throw new SyntaxError("JSON 객체를 찾을 수 없습니다.");
+  }
+
+  return JSON.parse(candidate.slice(start, end + 1));
+}
+
+type ParseSuccess = { ok: true; data: InferenceResponse };
+type ParseFailure = { ok: false; reason: "json" | "schema"; message: string };
+
+export function parseInferenceResponse(raw: string): ParseSuccess | ParseFailure {
+  let parsed: unknown;
+  try {
+    parsed = extractJson(raw);
+  } catch (e) {
+    return {
+      ok: false,
+      reason: "json",
+      message: e instanceof Error ? e.message : "JSON 파싱 실패",
+    };
+  }
+
+  const result = safeParseResponse(parsed);
+  if (!result.success) {
+    const message = result.error.issues[0]?.message ?? "응답 스키마 검증 실패";
+    return { ok: false, reason: "schema", message };
+  }
+
+  return { ok: true, data: result.data };
+}


### PR DESCRIPTION
## Summary

- `grok.ts`:
  - `GrokTimeoutError` / `GrokApiError` 커스텀 에러 클래스 추가
  - `AbortController` 기반 30초 timeout 적용
  - Grok 비-2xx → `GrokApiError` throw
- `route.ts` 에러 status 매핑 완성:
  - 400: 요청 검증 실패
  - 422: Grok 응답 파싱/Zod 검증 실패
  - 502: Grok API 오류 (비-2xx)
  - 504: Grok timeout (AbortError)
  - 500: 기타

closes #61

## Test plan
- [ ] `pnpm type-check` 통과
- [ ] `pnpm lint` 통과
- [ ] timeout 시 504 반환
- [ ] Grok 4xx/5xx 시 502 반환
- [ ] 정상 흐름 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
> ⚠️ 스택 머지 중 #233(SS-60-OutputParsing)이 base 브랜치 삭제로 자동 close됨. #60 파서 커밋을 이 브랜치에 함께 포함해 dev 기준으로 rebase 복구했습니다.

closes #60