### PR TITLE
chore: #212 FashionSelection.fashionMoods 필드 제거

### DIFF
--- a/src/hooks/useStepValidation.ts
+++ b/src/hooks/useStepValidation.ts
@@ -25,7 +25,7 @@ export const useStepValidation = () => {
     if (selectedDomain === "fashion") {
       const first = fashionSelections[0];
       if (!first) return false;
-      return first.styles.length > 0 || first.fashionMoods.length > 0;
+      return first.styles.length > 0;
     }
     return false;
   })();

--- a/src/lib/inference/inference.prompts.ts
+++ b/src/lib/inference/inference.prompts.ts
@@ -128,7 +128,7 @@ moods 키워드가 selections보다 우선순위가 높습니다.
 }
 
 [예시 3 — 패션 취향 입력]
-입력: 패션 취향 — 스타일: 스트릿, 오버핏 / 무드: 캐주얼한, 자유로운 / 감성 태그: 활기찬, 강렬한
+입력: 패션 취향 — 스타일: 스트릿, 오버핏 / 감성 태그: 활기찬, 강렬한
 출력:
 {
   "styleLabel": {
@@ -171,12 +171,7 @@ export function buildUserPrompt(req: InferenceRequest): string {
 
   if (req.domain === "fashion") {
     const styles = Array.from(new Set(req.selections.flatMap((s) => s.styles))).join(", ");
-    const fashionMoods = Array.from(new Set(req.selections.flatMap((s) => s.fashionMoods))).join(
-      ", "
-    );
-    return [`패션 취향 — 스타일: ${styles}`, `무드: ${fashionMoods}`, `감성 태그: ${moods}`].join(
-      " / "
-    );
+    return [`패션 취향 — 스타일: ${styles}`, `감성 태그: ${moods}`].join(" / ");
   }
 
   const _exhaustive: never = req;

--- a/src/lib/inference/inference.schema.ts
+++ b/src/lib/inference/inference.schema.ts
@@ -32,7 +32,6 @@ const FashionSelectionSchema = z.object({
   styles: z
     .array(z.string().min(1, { message: "스타일 항목은 비어있을 수 없습니다" }))
     .min(1, { message: "스타일은 최소 1개 이상 선택해주세요" }),
-  fashionMoods: z.array(MoodSchema).min(1, { message: "패션 무드는 최소 1개 이상 선택해주세요" }),
 });
 
 // ─── Request ──────────────────────────────────────────────────────────────────

--- a/src/lib/inference/normalizeRequest.ts
+++ b/src/lib/inference/normalizeRequest.ts
@@ -47,11 +47,10 @@ export const buildInferenceRequest = (args: BuildArgs): InferenceRequest => {
       moods: selectedStyles.movie ? [selectedStyles.movie] : [],
     };
   } else {
-    const fashion = args.fashionSelections[0] ?? { styles: [], fashionMoods: [] };
     candidate = {
       domain: "fashion",
       selections: args.fashionSelections,
-      moods: fashion.fashionMoods,
+      moods: selectedStyles.fashion ? [selectedStyles.fashion] : [],
     };
   }
 

--- a/src/store/tasteStore.ts
+++ b/src/store/tasteStore.ts
@@ -18,7 +18,6 @@ type TasteStore = {
   addMovieSelection: (item: MovieSelection) => void;
   removeMovieSelection: (id: number) => void;
   setFashionStyles: (styles: string[]) => void;
-  setFashionMoods: (moods: string[]) => void;
   reset: () => void;
 };
 
@@ -27,7 +26,7 @@ const initialState = {
   selectedStyles: {} as Partial<Record<Domain, string>>,
   musicSelections: [],
   movieSelections: [],
-  fashionSelections: [{ styles: [], fashionMoods: [] }] as FashionSelection[],
+  fashionSelections: [{ styles: [] }] as FashionSelection[],
 };
 
 export const useTasteStore = create<TasteStore>()(
@@ -69,11 +68,6 @@ export const useTasteStore = create<TasteStore>()(
       setFashionStyles: (styles) =>
         set((state) => ({
           fashionSelections: [{ ...state.fashionSelections[0], styles }],
-        })),
-
-      setFashionMoods: (moods) =>
-        set((state) => ({
-          fashionSelections: [{ ...state.fashionSelections[0], fashionMoods: moods }],
         })),
 
       reset: () => set(initialState),

--- a/src/types/taste.ts
+++ b/src/types/taste.ts
@@ -19,5 +19,4 @@ export type MovieSelection = {
 
 export type FashionSelection = {
   styles: string[];
-  fashionMoods: string[];
 };


### PR DESCRIPTION
## Summary
- `FashionSelection` 타입에서 `fashionMoods: string[]` 필드 제거
- `FashionSelectionSchema`에서 `fashionMoods` Zod 검증 제거
- `buildUserPrompt` 패션 도메인에서 `무드: ${fashionMoods}` 라인 제거
- `tasteStore`에서 `setFashionMoods` 액션 제거
- `useStepValidation`, `normalizeRequest` 관련 참조 정리

## Test plan
- [ ] `pnpm type-check` 통과
- [ ] `pnpm lint` 통과
- [ ] 패션 도메인 취향 입력 UI 정상 동작 확인

closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)