### PR TITLE
chore: #188 Domain export 경로 단일화 — @/lib/inference 제거

### DIFF
--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -6,7 +6,6 @@ export type {
   MovieRecommendation,
   FashionRecommendation,
   StyleLabel,
-  Domain,
   IInferenceService,
 } from "./inference.types";
 

--- a/src/lib/inference/inference.mocks.ts
+++ b/src/lib/inference/inference.mocks.ts
@@ -1,6 +1,8 @@
+import type { Domain } from "@/types/taste";
+
 import { InferenceResponseSchema } from "./inference.schema";
 
-import type { Domain, InferenceResponse } from "./inference.types";
+import type { InferenceResponse } from "./inference.types";
 
 // ─── Music ────────────────────────────────────────────────────────────────────
 

--- a/src/lib/inference/inference.types.ts
+++ b/src/lib/inference/inference.types.ts
@@ -1,5 +1,5 @@
 import type { StyleLabel } from "@/types/result";
-import type { Domain, MusicSelection, MovieSelection, FashionSelection } from "@/types/taste";
+import type { MusicSelection, MovieSelection, FashionSelection } from "@/types/taste";
 
 // ─── Request ──────────────────────────────────────────────────────────────────
 
@@ -36,8 +36,6 @@ export type InferenceResponse = {
   movie: MovieRecommendation[];
   fashion: FashionRecommendation[];
 };
-
-export type { Domain };
 
 // ─── Utility types ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `inference.types.ts`에서 `Domain` re-export 제거
- `src/lib/inference/index.ts` 배럴에서 `Domain` 제거
- `inference.mocks.ts`의 `Domain` import를 `@/types/taste`로 직접 변경

`Domain` 타입의 canonical 경로를 `@/types/taste` 단일 경로로 통일.

## Test plan
- [ ] `pnpm type-check` 통과
- [ ] `pnpm lint` 통과

closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)