### PR TITLE
refactor: #187 StyleLabel 컴포넌트 → StyleLabelCard rename

### DIFF
--- a/src/components/result/styleLabel/StyleLabel.tsx
+++ b/src/components/result/styleLabel/StyleLabel.tsx
@@ -1,3 +1,3 @@
-export const StyleLabel = () => {
+export const StyleLabelCard = () => {
   return null;
 };

--- a/src/components/result/styleLabel/index.ts
+++ b/src/components/result/styleLabel/index.ts
@@ -1,3 +1,3 @@
-export { StyleLabel } from "./StyleLabel";
+export { StyleLabelCard } from "./StyleLabel";
 export { StyleLabelHero } from "./StyleLabelHero";
 export type { IStyleLabelHeroProps } from "./StyleLabelHero";


### PR DESCRIPTION
## Summary
- `StyleLabel` 컴포넌트 export명을 `StyleLabelCard`로 변경
- `@/types/result`의 `StyleLabel` 타입과의 이름 충돌 해소

`StyleLabel` 식별자가 타입과 컴포넌트 두 곳에서 export되어 IDE 자동완성 혼선이 발생했습니다.
컴포넌트가 현재 stub 상태이므로 파급 범위 없이 rename 가능합니다.

## Test plan
- [ ] `pnpm type-check` 통과
- [ ] `pnpm lint` 통과

closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)