### PR TITLE
feat: #222 TasteCard 선택 개수별 안내 메시지 UI 구현

### DIFF
--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -71,13 +71,10 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
     if (domain === "fashion") router.replace("/taste/fashion");
   }, [domain, router]);
 
-  // 도메인별 선택 상태로 분기 (music/movie 영향 분리)
-  const isReady =
-    domain === "music"
-      ? musicSelections.length > 0
-      : domain === "movie"
-        ? movieSelections.length > 0
-        : false;
+  const selectionCount =
+    domain === "music" ? musicSelections.length : domain === "movie" ? movieSelections.length : 0;
+
+  const isReady = selectionCount >= 3;
 
   const [searchQuery, setSearchQuery] = useState("");
   const content = DETAIL_CONTENT[domain];
@@ -143,6 +140,7 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
         onSearchChange={setSearchQuery}
         isNextDisabled={!isReady || isAnalyzing}
         onNext={handleAnalyze}
+        selectionCount={selectionCount}
       >
         {/* 2뎁스: TasteCard 그리드 */}
         <div className="grid-cols-responsive">

--- a/src/components/domain/tasteInputForm/TasteInputForm.tsx
+++ b/src/components/domain/tasteInputForm/TasteInputForm.tsx
@@ -23,6 +23,11 @@ const SearchIcon = () => (
   </svg>
 );
 
+function getSelectionMessage(count: number, max: number): { text: string; done: boolean } {
+  if (count >= max) return { text: "완벽해요! 분석을 시작할게요", done: true };
+  return { text: `${max - count}개 더 선택해주세요`, done: false };
+}
+
 export function TasteInputForm({
   title,
   description,
@@ -33,7 +38,11 @@ export function TasteInputForm({
   children,
   isNextDisabled,
   onNext,
+  selectionCount,
+  maxSelections = 3,
 }: ITasteInputFormProps) {
+  const selectionMsg =
+    selectionCount !== undefined ? getSelectionMessage(selectionCount, maxSelections) : null;
   return (
     <div className="page-container section-wrapper">
       <header className="mb-8 flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
@@ -77,6 +86,16 @@ export function TasteInputForm({
       </div>
 
       <section className="min-h-[60vh]">{children}</section>
+
+      {selectionMsg && (
+        <p
+          className={`mb-2 text-center text-sm font-medium ${
+            selectionMsg.done ? "text-primary-container" : "text-stone-400"
+          }`}
+        >
+          {selectionMsg.text}
+        </p>
+      )}
 
       <BottomNav
         prevPath={`/taste/${domain}`}

--- a/src/components/domain/tasteInputForm/tasteInputForm.types.ts
+++ b/src/components/domain/tasteInputForm/tasteInputForm.types.ts
@@ -15,4 +15,7 @@ export interface ITasteInputFormProps {
 
   isNextDisabled?: boolean;
   onNext?: () => void;
+
+  selectionCount?: number;
+  maxSelections?: number;
 }


### PR DESCRIPTION
## Summary
- `TasteInputForm`에 `selectionCount` / `maxSelections` prop 추가
- BottomNav 상단에 개수별 안내 메시지 표시
  - 0~2개: `"n개 더 선택해주세요"` (stone-400)
  - 3개: `"완벽해요! 분석을 시작할게요"` (primary-container 색상)
- `detail/page.tsx` 버튼 활성화 조건: `> 0` → `>= 3` 수정 (FT-002 명세 준수)

## Test plan
- [ ] `pnpm type-check` 통과
- [ ] `pnpm lint` 통과
- [ ] 음악/영화 2뎁스에서 카드 선택 개수에 따라 안내 메시지 변화 확인
- [ ] 3개 선택 시 CTA 버튼 활성화 확인

closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)