### PR TITLE
chore / SS-240-CITypeCheckLint - PR CI(type-check + lint) 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+jobs:
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run type check
+        run: pnpm type-check
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run lint
+        run: pnpm lint


### PR DESCRIPTION
## 반영 브랜치
SS-240-CITypeCheckLint → dev

## PR 타입
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 작업 내용
PR(main/dev 대상)마다 type-check와 lint를 자동 검증하는 GitHub Actions 워크플로우 추가.

- `.github/workflows/ci.yml` 신설
  - `type-check` job: `pnpm type-check` (tsc --noEmit)
  - `lint` job: `pnpm lint` (next lint)
  - pnpm 10 + Node 22, `--frozen-lockfile` 설치

## 배경
스택드 PR 머지 중 타입/린트 회귀를 리뷰어가 수동으로만 확인하던 문제를 자동화. 머지 전 CI 게이트로 회귀를 원천 차단.

## 후속 (레포 관리자)
머지 후 dev branch protection에서 `Type Check` / `Lint` status check를 required로 등록 + "Require branches to be up to date" 활성화 예정.

## 테스트 결과
- dev 기준 로컬 검증: `pnpm type-check` 통과, `pnpm lint` 통과(No ESLint warnings or errors)

Closes #240