### PR TITLE
feat: closes #63 추천 결과 정규화 유틸 — 중복 제거 + 필드 절단

### DIFF
--- a/src/app/api/inference/route.ts
+++ b/src/app/api/inference/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { GrokApiError, GrokTimeoutError, callGrok } from "@/lib/grok";
 import { enrichResponseWithTmdb } from "@/lib/inference/enrichResponse";
+import { normalizeInferenceResponse } from "@/lib/inference/inference.normalize";
 import { parseInferenceResponse } from "@/lib/inference/inference.parser";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/inference/inference.prompts";
 import { safeParseRequest } from "@/lib/inference/inference.schema";
@@ -38,7 +39,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ message: parsed.message }, { status: 422 });
   }
 
-  const enriched = await enrichResponseWithTmdb(parsed.data);
+  const normalized = normalizeInferenceResponse(parsed.data);
+  const enriched = await enrichResponseWithTmdb(normalized);
 
   const result: InferenceResult = {
     ...enriched,

--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -29,5 +29,7 @@ export { SYSTEM_PROMPT, buildUserPrompt } from "./inference.prompts";
 
 export { parseInferenceResponse } from "./inference.parser";
 
+export { normalizeInferenceResponse } from "./inference.normalize";
+
 export { callGrok } from "@/lib/grok";
 export type { GrokMessage } from "@/lib/grok";

--- a/src/lib/inference/inference.normalize.ts
+++ b/src/lib/inference/inference.normalize.ts
@@ -1,0 +1,34 @@
+import type {
+  FashionRecommendation,
+  MovieRecommendation,
+  MusicRecommendation,
+} from "./inference.schema";
+import type { InferenceResponse } from "./inference.types";
+
+const dedupeById = <T extends { id: string | number }>(items: T[]): T[] =>
+  items.filter((v, i, a) => a.findIndex((x) => x.id === v.id) === i);
+
+const dedupeByKeyword = <T extends { keyword: string }>(items: T[]): T[] =>
+  items.filter((v, i, a) => a.findIndex((x) => x.keyword === v.keyword) === i);
+
+const normalizeMusic = (items: MusicRecommendation[]): MusicRecommendation[] =>
+  dedupeById(items).map((m) => ({ ...m, name: m.name.trim(), artist: m.artist.trim() }));
+
+const normalizeMovie = (items: MovieRecommendation[]): MovieRecommendation[] =>
+  dedupeById(items).map((m) => ({ ...m, title: m.title.trim(), posterPath: m.posterPath.trim() }));
+
+const normalizeFashion = (items: FashionRecommendation[]): FashionRecommendation[] =>
+  dedupeByKeyword(items).map((f) => ({ ...f, keyword: f.keyword.trim() }));
+
+// Grok 응답 정규화 — 중복 제거, 앞뒤 공백 제거, 스키마 한도 초과 필드 절단
+export const normalizeInferenceResponse = (response: InferenceResponse): InferenceResponse => ({
+  ...response,
+  styleLabel: {
+    ...response.styleLabel,
+    title: response.styleLabel.title.trim().slice(0, 30),
+    description: response.styleLabel.description.trim().slice(0, 80),
+  },
+  music: normalizeMusic(response.music),
+  movie: normalizeMovie(response.movie),
+  fashion: normalizeFashion(response.fashion),
+});


### PR DESCRIPTION
## Summary
- `inference.normalize.ts` 신설: Grok 응답 정규화 유틸
  - music/movie: `id` 기준 중복 제거
  - fashion: `keyword` 기준 중복 제거
  - 모든 문자열 필드 앞뒤 공백 trim
  - `styleLabel.title` ≤30자, `description` ≤80자 스키마 한도 절단
- `route.ts`: 파싱 직후, TMDB enrichment 전에 `normalizeInferenceResponse` 적용
- `index.ts`: 배럴에 `normalizeInferenceResponse` re-export

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [ ] POST /api/inference — 중복 트랙/영화/패션 키워드가 포함된 응답이 정규화되어 반환되는지 확인

closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)