### PR TITLE
feat: closes #65 빈 추천 배열 mock fallback 처리

### DIFF
--- a/src/app/api/inference/route.ts
+++ b/src/app/api/inference/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { GrokApiError, GrokTimeoutError, callGrok } from "@/lib/grok";
 import { enrichResponseWithTmdb } from "@/lib/inference/enrichResponse";
+import { applyFallback } from "@/lib/inference/inference.fallback";
 import { normalizeInferenceResponse } from "@/lib/inference/inference.normalize";
 import { parseInferenceResponse } from "@/lib/inference/inference.parser";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/inference/inference.prompts";
@@ -40,7 +41,8 @@ export async function POST(req: NextRequest) {
   }
 
   const normalized = normalizeInferenceResponse(parsed.data);
-  const enriched = await enrichResponseWithTmdb(normalized);
+  const fallbacked = applyFallback(normalized, parsedReq.data.domain);
+  const enriched = await enrichResponseWithTmdb(fallbacked);
 
   const result: InferenceResult = {
     ...enriched,

--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -31,5 +31,7 @@ export { parseInferenceResponse } from "./inference.parser";
 
 export { normalizeInferenceResponse } from "./inference.normalize";
 
+export { applyFallback } from "./inference.fallback";
+
 export { callGrok } from "@/lib/grok";
 export type { GrokMessage } from "@/lib/grok";

--- a/src/lib/inference/inference.fallback.ts
+++ b/src/lib/inference/inference.fallback.ts
@@ -1,0 +1,16 @@
+import type { Domain } from "@/types/taste";
+
+import { getMockByDomain } from "./inference.mocks";
+
+import type { InferenceResponse } from "./inference.types";
+
+// 빈 추천 배열을 도메인 mock으로 대체 — Grok이 항목을 반환하지 못한 경우 UI 공백 방지
+export const applyFallback = (response: InferenceResponse, domain: Domain): InferenceResponse => {
+  const mock = getMockByDomain(domain);
+  return {
+    ...response,
+    music: response.music.length > 0 ? response.music : mock.music,
+    movie: response.movie.length > 0 ? response.movie : mock.movie,
+    fashion: response.fashion.length > 0 ? response.fashion : mock.fashion,
+  };
+};


### PR DESCRIPTION
## Summary
- `inference.fallback.ts` 신설: `applyFallback(response, domain)`
  - Grok이 music/movie/fashion 배열을 비워서 반환할 경우 해당 domain의 mock 데이터로 대체
  - styleLabel은 유지 (Grok 응답 우선)
- `route.ts`: `normalizeInferenceResponse` 직후, TMDB enrichment 전에 `applyFallback` 적용
- `index.ts`: 배럴에 `applyFallback` re-export

> 스택 PR — #245(SS-63-NormalizeResult)가 dev에 먼저 머지되면 이 PR의 base를 dev로 전환해 주세요.

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [ ] Grok이 빈 배열을 반환하는 경우 mock 데이터로 대체되는지 확인

closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)