### PR TITLE
feat: closes #64 결과 품질 확인용 fixture + node 유닛 테스트 환경

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
     "type-check": "tsc --noEmit",
+    "test:node": "vitest run --project node",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "prepare": "husky"

--- a/src/app/api/inference/route.ts
+++ b/src/app/api/inference/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { GrokApiError, GrokTimeoutError, callGrok } from "@/lib/grok";
 import { enrichResponseWithTmdb } from "@/lib/inference/enrichResponse";
+import { applyFallback } from "@/lib/inference/inference.fallback";
 import { normalizeInferenceResponse } from "@/lib/inference/inference.normalize";
 import { parseInferenceResponse } from "@/lib/inference/inference.parser";
 import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/inference/inference.prompts";
@@ -40,7 +41,8 @@ export async function POST(req: NextRequest) {
   }
 
   const normalized = normalizeInferenceResponse(parsed.data);
-  const enriched = await enrichResponseWithTmdb(normalized);
+  const fallbacked = applyFallback(normalized, parsedReq.data.domain);
+  const enriched = await enrichResponseWithTmdb(fallbacked);
 
   const result: InferenceResult = {
     ...enriched,

--- a/src/lib/inference/__fixtures__/inferenceResponse.fixture.ts
+++ b/src/lib/inference/__fixtures__/inferenceResponse.fixture.ts
@@ -1,0 +1,100 @@
+import type { InferenceResponse } from "../inference.types";
+
+export const baseResponse: InferenceResponse = {
+  styleLabel: {
+    title: "Melancholic Indie",
+    description: "감성적인 기타 리프와 몽환적인 보컬이 교차하는 서정적 인디 팝",
+    themeColor: "#dce8f0",
+    mood: { energy: "low", tone: "neutral", aesthetic: "indie" },
+  },
+  music: [
+    { id: "track:001", name: "Cherry Wine", artist: "Hozier", image: "/img/1", previewUrl: null },
+    {
+      id: "track:002",
+      name: "Motion Sickness",
+      artist: "Phoebe Bridgers",
+      image: "/img/2",
+      previewUrl: null,
+    },
+  ],
+  movie: [
+    { id: 1001, title: "비포 선라이즈", posterPath: "/before-sunrise.jpg", genres: ["로맨스"] },
+    { id: 1002, title: "이터널 선샤인", posterPath: "/eternal-sunshine.jpg", genres: ["SF"] },
+  ],
+  fashion: [
+    { keyword: "oversized denim jacket", image: "/fashion/1" },
+    { keyword: "striped knit sweater", image: "/fashion/2" },
+  ],
+};
+
+export const responseWithDuplicates: InferenceResponse = {
+  ...baseResponse,
+  music: [
+    { id: "track:001", name: "Cherry Wine", artist: "Hozier", image: "/img/1", previewUrl: null },
+    {
+      id: "track:001",
+      name: "Cherry Wine (dup)",
+      artist: "Hozier",
+      image: "/img/1",
+      previewUrl: null,
+    },
+    {
+      id: "track:002",
+      name: "Motion Sickness",
+      artist: "Phoebe Bridgers",
+      image: "/img/2",
+      previewUrl: null,
+    },
+  ],
+  movie: [
+    { id: 1001, title: "비포 선라이즈", posterPath: "/before-sunrise.jpg", genres: ["로맨스"] },
+    {
+      id: 1001,
+      title: "비포 선라이즈 (dup)",
+      posterPath: "/before-sunrise.jpg",
+      genres: ["로맨스"],
+    },
+  ],
+  fashion: [
+    { keyword: "oversized denim jacket", image: "/fashion/1" },
+    { keyword: "oversized denim jacket", image: "/fashion/1" },
+  ],
+};
+
+export const responseWithEmptyArrays: InferenceResponse = {
+  ...baseResponse,
+  music: [],
+  movie: [],
+  fashion: [],
+};
+
+export const responseWithLongFields: InferenceResponse = {
+  ...baseResponse,
+  styleLabel: {
+    ...baseResponse.styleLabel,
+    title: "A".repeat(40),
+    description: "B".repeat(100),
+  },
+};
+
+export const responseWithWhitespace: InferenceResponse = {
+  ...baseResponse,
+  music: [
+    {
+      id: "track:001",
+      name: "  Cherry Wine  ",
+      artist: "  Hozier  ",
+      image: "/img/1",
+      previewUrl: null,
+    },
+  ],
+  movie: [
+    {
+      id: 1001,
+      title: "  비포 선라이즈  ",
+      posterPath: "  /before-sunrise.jpg  ",
+      genres: ["로맨스"],
+    },
+  ],
+  fashion: [{ keyword: "  oversized denim jacket  ", image: "/fashion/1" }],
+};

--- a/src/lib/inference/__tests__/inference.fallback.test.ts
+++ b/src/lib/inference/__tests__/inference.fallback.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { baseResponse, responseWithEmptyArrays } from "../__fixtures__/inferenceResponse.fixture";
+import { applyFallback } from "../inference.fallback";
+import { getMockByDomain } from "../inference.mocks";
+
+describe("applyFallback", () => {
+  it("모든 배열이 채워진 경우 원본 데이터를 그대로 유지한다", () => {
+    const result = applyFallback(baseResponse, "music");
+    expect(result.music).toEqual(baseResponse.music);
+    expect(result.movie).toEqual(baseResponse.movie);
+    expect(result.fashion).toEqual(baseResponse.fashion);
+  });
+
+  it("빈 music 배열을 해당 domain mock으로 대체한다", () => {
+    const mock = getMockByDomain("music");
+    const result = applyFallback(responseWithEmptyArrays, "music");
+    expect(result.music).toEqual(mock.music);
+  });
+
+  it("빈 movie 배열을 해당 domain mock으로 대체한다", () => {
+    const mock = getMockByDomain("movie");
+    const result = applyFallback(responseWithEmptyArrays, "movie");
+    expect(result.movie).toEqual(mock.movie);
+  });
+
+  it("빈 fashion 배열을 해당 domain mock으로 대체한다", () => {
+    const mock = getMockByDomain("fashion");
+    const result = applyFallback(responseWithEmptyArrays, "fashion");
+    expect(result.fashion).toEqual(mock.fashion);
+  });
+
+  it("domain에 따라 세 배열 모두 동일 mock에서 대체한다", () => {
+    const mock = getMockByDomain("movie");
+    const result = applyFallback(responseWithEmptyArrays, "movie");
+    expect(result.music).toEqual(mock.music);
+    expect(result.movie).toEqual(mock.movie);
+    expect(result.fashion).toEqual(mock.fashion);
+  });
+
+  it("styleLabel은 fallback 대상이 아니므로 원본을 유지한다", () => {
+    const result = applyFallback(responseWithEmptyArrays, "music");
+    expect(result.styleLabel).toEqual(responseWithEmptyArrays.styleLabel);
+  });
+});

--- a/src/lib/inference/__tests__/inference.normalize.test.ts
+++ b/src/lib/inference/__tests__/inference.normalize.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  baseResponse,
+  responseWithDuplicates,
+  responseWithLongFields,
+  responseWithWhitespace,
+} from "../__fixtures__/inferenceResponse.fixture";
+import { normalizeInferenceResponse } from "../inference.normalize";
+
+describe("normalizeInferenceResponse", () => {
+  it("중복 music 항목을 id 기준 첫 번째만 남긴다", () => {
+    const result = normalizeInferenceResponse(responseWithDuplicates);
+    expect(result.music).toHaveLength(2);
+    expect(result.music[0].name).toBe("Cherry Wine");
+  });
+
+  it("중복 movie 항목을 id 기준 첫 번째만 남긴다", () => {
+    const result = normalizeInferenceResponse(responseWithDuplicates);
+    expect(result.movie).toHaveLength(1);
+    expect(result.movie[0].title).toBe("비포 선라이즈");
+  });
+
+  it("중복 fashion 항목을 keyword 기준 첫 번째만 남긴다", () => {
+    const result = normalizeInferenceResponse(responseWithDuplicates);
+    expect(result.fashion).toHaveLength(1);
+  });
+
+  it("title을 30자 이하로 절단한다", () => {
+    const result = normalizeInferenceResponse(responseWithLongFields);
+    expect(result.styleLabel.title.length).toBeLessThanOrEqual(30);
+  });
+
+  it("description을 80자 이하로 절단한다", () => {
+    const result = normalizeInferenceResponse(responseWithLongFields);
+    expect(result.styleLabel.description.length).toBeLessThanOrEqual(80);
+  });
+
+  it("music name과 artist의 앞뒤 공백을 제거한다", () => {
+    const result = normalizeInferenceResponse(responseWithWhitespace);
+    expect(result.music[0].name).toBe("Cherry Wine");
+    expect(result.music[0].artist).toBe("Hozier");
+  });
+
+  it("movie title의 앞뒤 공백을 제거한다", () => {
+    const result = normalizeInferenceResponse(responseWithWhitespace);
+    expect(result.movie[0].title).toBe("비포 선라이즈");
+  });
+
+  it("fashion keyword의 앞뒤 공백을 제거한다", () => {
+    const result = normalizeInferenceResponse(responseWithWhitespace);
+    expect(result.fashion[0].keyword).toBe("oversized denim jacket");
+  });
+
+  it("정상 응답의 배열 길이를 유지한다", () => {
+    const result = normalizeInferenceResponse(baseResponse);
+    expect(result.music).toHaveLength(baseResponse.music.length);
+    expect(result.movie).toHaveLength(baseResponse.movie.length);
+    expect(result.fashion).toHaveLength(baseResponse.fashion.length);
+  });
+
+  it("styleLabel의 나머지 필드(themeColor, mood)는 변경하지 않는다", () => {
+    const result = normalizeInferenceResponse(baseResponse);
+    expect(result.styleLabel.themeColor).toBe(baseResponse.styleLabel.themeColor);
+    expect(result.styleLabel.mood).toEqual(baseResponse.styleLabel.mood);
+  });
+});

--- a/src/lib/inference/index.ts
+++ b/src/lib/inference/index.ts
@@ -31,5 +31,7 @@ export { parseInferenceResponse } from "./inference.parser";
 
 export { normalizeInferenceResponse } from "./inference.normalize";
 
+export { applyFallback } from "./inference.fallback";
+
 export { callGrok } from "@/lib/grok";
 export type { GrokMessage } from "@/lib/grok";

--- a/src/lib/inference/inference.fallback.ts
+++ b/src/lib/inference/inference.fallback.ts
@@ -1,0 +1,16 @@
+import type { Domain } from "@/types/taste";
+
+import { getMockByDomain } from "./inference.mocks";
+
+import type { InferenceResponse } from "./inference.types";
+
+// 빈 추천 배열을 도메인 mock으로 대체 — Grok이 항목을 반환하지 못한 경우 UI 공백 방지
+export const applyFallback = (response: InferenceResponse, domain: Domain): InferenceResponse => {
+  const mock = getMockByDomain(domain);
+  return {
+    ...response,
+    music: response.music.length > 0 ? response.music : mock.music,
+    movie: response.movie.length > 0 ? response.movie : mock.movie,
+    fashion: response.fashion.length > 0 ? response.fashion : mock.fashion,
+  };
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,14 @@ export default defineConfig({
   test: {
     projects: [
       {
+        test: {
+          name: 'node',
+          environment: 'node',
+          include: ['src/**/__tests__/**/*.test.ts'],
+          alias: { '@': path.resolve(dirname, 'src') },
+        },
+      },
+      {
         extends: true,
         plugins: [
           // The plugin will run tests for the stories defined in your Storybook config


### PR DESCRIPTION
## Summary
- `vitest.config.ts`: `node` project 추가 — `src/**/__tests__/**/*.test.ts` 대상, `@` alias 설정
- `package.json`: `test:node` 스크립트 추가 (`vitest run --project node`)
- `__fixtures__/inferenceResponse.fixture.ts` 신설 — 5종 fixture:
  - `baseResponse` — 정상 응답
  - `responseWithDuplicates` — music/movie/fashion 각 배열에 중복 항목 포함
  - `responseWithEmptyArrays` — 세 추천 배열 모두 빈 배열
  - `responseWithLongFields` — title/description 스키마 한도 초과
  - `responseWithWhitespace` — 앞뒤 공백 포함 필드
- `__tests__/inference.normalize.test.ts` — 정규화 유틸 10케이스
- `__tests__/inference.fallback.test.ts` — fallback 유틸 6케이스

> 스택 PR — #246(SS-65-Fallback)이 dev에 먼저 머지되면 이 PR의 base를 dev로 전환해 주세요.

## Test plan
- [x] `pnpm test:node` — 2 files, 16 tests 통과
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과

closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
> 스택 머지 중 #246(SS-65-Fallback)이 base 브랜치 삭제로 자동 close됨. #65 fallback 커밋을 이 브랜치에 포함해 dev 기준으로 rebase 복구했습니다.

closes #65