### PR TITLE
feat / SS-18-CommonLoadingErrorUI - 공통 loading / error UI 작성

### DIFF
--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -9,6 +9,7 @@ import { InputSummary } from "@/components/domain/inputSummary";
 import { MovieTasteCard } from "@/components/domain/movieTasteCard";
 import { MusicTasteCard } from "@/components/domain/musicTasteCard";
 import { TasteInputForm } from "@/components/domain/tasteInputForm";
+import { StatusPanel } from "@/components/ui/feedback/StatusPanel";
 import { useInference } from "@/hooks/useInference";
 import { buildInferenceRequest } from "@/lib/inference/normalizeRequest";
 import { useResultStore } from "@/store/resultStore";
@@ -188,23 +189,39 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
         )}
         <div className="grid-cols-responsive">
           {isSearchLoading && (
-            <p className="col-span-full py-10 text-center text-sm text-stone-400">검색 중...</p>
+            <StatusPanel
+              size="compact"
+              variant="loading"
+              title="검색 결과를 불러오는 중이에요"
+              description="입력한 키워드를 기준으로 추천 후보를 찾고 있습니다."
+            />
           )}
 
           {!isSearchLoading && searchError && (
-            <p className="col-span-full py-10 text-center text-sm text-red-400">{searchError}</p>
+            <StatusPanel
+              size="compact"
+              variant="error"
+              title="검색 결과를 불러오지 못했어요"
+              description={searchError}
+            />
           )}
 
           {!isSearchLoading && !searchError && searchQuery && searchResults.length === 0 && (
-            <p className="col-span-full py-10 text-center text-sm text-stone-400">
-              검색 결과가 없습니다.
-            </p>
+            <StatusPanel
+              size="compact"
+              variant="empty"
+              title="검색 결과가 없어요"
+              description="다른 키워드나 제목으로 다시 검색해보세요."
+            />
           )}
 
           {!isSearchLoading && !searchError && !searchQuery && (
-            <p className="col-span-full py-10 text-center text-sm text-stone-400">
-              {content.searchPlaceholder}을 입력해 결과를 확인하세요.
-            </p>
+            <StatusPanel
+              size="compact"
+              variant="empty"
+              title="검색어를 입력해보세요"
+              description={`${content.searchPlaceholder}를 입력하면 추천 후보를 보여드릴게요.`}
+            />
           )}
 
           {domain === "music" &&

--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -62,8 +62,15 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
 
   // fashion은 2뎁스 미사용 → 1뎁스로 되돌림
   useEffect(() => {
-    if (domain === "fashion") router.replace("/taste/fashion");
-  }, [domain, router]);
+    if (domain === "fashion") {
+      router.replace("/taste/fashion");
+      return;
+    }
+
+    if (!selectedStyles[domain]) {
+      router.replace(`/taste/${domain}`);
+    }
+  }, [domain, router, selectedStyles]);
 
   const fetchResults = useCallback(
     async (query: string) => {

--- a/src/components/ui/feedback/StatusPanel.tsx
+++ b/src/components/ui/feedback/StatusPanel.tsx
@@ -1,0 +1,73 @@
+import { Button } from "@/components/ui/button";
+
+type StatusPanelVariant = "loading" | "error" | "empty";
+type StatusPanelSize = "compact" | "page";
+
+type StatusPanelProps = {
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+  size?: StatusPanelSize;
+  variant?: StatusPanelVariant;
+};
+
+const VARIANT_STYLES: Record<StatusPanelVariant, { badge: string; title: string }> = {
+  loading: {
+    badge: "bg-primary-container/15 text-primary-container",
+    title: "text-on-background",
+  },
+  error: {
+    badge: "bg-destructive/10 text-destructive",
+    title: "text-on-background",
+  },
+  empty: {
+    badge: "bg-surface-variant text-on-surface-variant",
+    title: "text-on-background",
+  },
+};
+
+const BADGE_LABEL: Record<StatusPanelVariant, string> = {
+  loading: "LOADING",
+  error: "ERROR",
+  empty: "EMPTY",
+};
+
+export const StatusPanel = ({
+  title,
+  description,
+  actionLabel,
+  onAction,
+  size = "page",
+  variant = "empty",
+}: StatusPanelProps) => {
+  const styles = VARIANT_STYLES[variant];
+  const isPage = size === "page";
+
+  return (
+    <section
+      className={
+        isPage
+          ? "flex min-h-[60vh] flex-col items-center justify-center rounded-lg bg-surface px-6 py-12 text-center"
+          : "col-span-full flex min-h-[220px] flex-col items-center justify-center rounded-lg border border-outline-variant bg-surface px-6 py-10 text-center"
+      }
+      role={variant === "error" ? "alert" : "status"}
+      aria-live={variant === "error" ? "assertive" : "polite"}
+    >
+      <span className={`rounded-full px-3 py-1 type-label-sm ${styles.badge}`}>
+        {BADGE_LABEL[variant]}
+      </span>
+      <h2 className={`mt-4 type-headline-sm ${styles.title}`}>{title}</h2>
+      {description ? (
+        <p className="mt-3 max-w-[32rem] type-body-md keep-all text-on-surface-variant">
+          {description}
+        </p>
+      ) : null}
+      {actionLabel && onAction ? (
+        <Button className="mt-6" variant="stroke" size="sm" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      ) : null}
+    </section>
+  );
+};


### PR DESCRIPTION
## PR 제목

feat / SS-18-CommonLoadingErrorUI - 공통 loading / error UI 작성

## PR 본문

### 반영 브랜치

SS-18-CommonLoadingErrorUI -> dev

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 내용

- 공통 상태 UI 컴포넌트 StatusPanel을 추가해 loading / error / empty 상태를 일관되게 표현
- loading-result 페이지에 공통 loading UI 적용
- 결과 페이지 에러 UI와 검색 중 / 검색 실패 / 검색 결과 없음 상태를 공통 컴포넌트 기반으로 정리

Closes [#18](https://github.com/Style-Sync/stylesync/issues/18)