### PR TITLE
feat: closes #33 입력 요약 컴포넌트 구현

### DIFF
--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { DomainGuard } from "@/components/domain/DomainGuard";
+import { InputSummary } from "@/components/domain/inputSummary";
 import { MovieTasteCard } from "@/components/domain/movieTasteCard";
 import { MusicTasteCard } from "@/components/domain/musicTasteCard";
 import { TasteInputForm } from "@/components/domain/tasteInputForm";
@@ -157,6 +158,24 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
         onNext={handleAnalyze}
         selectionCount={selectionCount}
       >
+        {domain === "music" && (
+          <InputSummary
+            label="선택한 아티스트"
+            items={musicSelections.map((s) => ({ id: s.id, name: s.name, imageUrl: s.image }))}
+            onRemove={(id) => removeMusicSelection(id as string)}
+          />
+        )}
+        {domain === "movie" && (
+          <InputSummary
+            label="선택한 영화"
+            items={movieSelections.map((s) => ({
+              id: s.id,
+              name: s.title,
+              imageUrl: s.posterPath,
+            }))}
+            onRemove={(id) => removeMovieSelection(id as number)}
+          />
+        )}
         <div className="grid-cols-responsive">
           {isSearchLoading && (
             <p className="col-span-full py-10 text-center text-sm text-stone-400">검색 중...</p>

--- a/src/components/domain/inputSummary/InputSummary.tsx
+++ b/src/components/domain/inputSummary/InputSummary.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Image from "next/image";
+
+import type { IInputSummaryProps } from "./inputSummary.types";
+
+export function InputSummary({ items, onRemove, label }: IInputSummaryProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className="mb-6">
+      {label && (
+        <p className="mb-3 text-xs font-medium uppercase tracking-wider text-on-surface-variant">
+          {label}
+        </p>
+      )}
+      <div className="flex gap-4 overflow-x-auto pb-1">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="relative flex w-16 flex-shrink-0 flex-col items-center gap-1.5"
+          >
+            <div className="relative h-14 w-14 overflow-hidden rounded-full bg-surface-variant">
+              {item.imageUrl && (
+                <Image src={item.imageUrl} alt={item.name} fill className="object-cover" />
+              )}
+              <button
+                type="button"
+                onClick={() => onRemove(item.id)}
+                aria-label={`${item.name} 선택 해제`}
+                className="absolute -right-0.5 -top-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary-container text-xs leading-none text-white shadow-sm"
+              >
+                ×
+              </button>
+            </div>
+            <span className="w-full truncate text-center text-xs leading-tight text-on-background">
+              {item.name}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/domain/inputSummary/index.ts
+++ b/src/components/domain/inputSummary/index.ts
@@ -1,0 +1,2 @@
+export { InputSummary } from "./InputSummary";
+export type { InputSummaryItem, IInputSummaryProps } from "./inputSummary.types";

--- a/src/components/domain/inputSummary/inputSummary.types.ts
+++ b/src/components/domain/inputSummary/inputSummary.types.ts
@@ -1,0 +1,11 @@
+export type InputSummaryItem = {
+  id: string | number;
+  name: string;
+  imageUrl?: string;
+};
+
+export interface IInputSummaryProps {
+  items: InputSummaryItem[];
+  onRemove: (id: string | number) => void;
+  label?: string;
+}


### PR DESCRIPTION
## Summary
- `InputSummary` 컴포넌트 신설 (`src/components/domain/inputSummary/`)
  - 선택된 아티스트/영화를 원형 이미지 칩 + 이름으로 표시
  - 우상단 × 버튼으로 개별 해제 가능
  - 선택 0개일 때 자동으로 null 반환 (레이아웃 변화 없음)
- `detail/page.tsx`: 검색 그리드 상단에 `InputSummary` 연결
  - music → `musicSelections`(id/name/image) + `removeMusicSelection`
  - movie → `movieSelections`(id/title/posterPath) + `removeMovieSelection`

## Test plan
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과
- [ ] `/taste/music/detail` — 아티스트 3개 선택 시 칩 행 표시, × 클릭 시 해제 확인
- [ ] `/taste/movie/detail` — 영화 선택 시 포스터 썸네일 칩 표시 확인
- [ ] 선택 0개 상태에서 InputSummary 영역 미노출 확인

closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)