### PR TITLE
fix: closes #138 #139 #140 #141 QA E2E 시나리오 점검 및 버그 수정

### DIFF
--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -57,6 +57,7 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
   const [searchResults, setSearchResults] = useState<MusicSelection[] | MovieSelection[]>([]);
   const [isSearchLoading, setIsSearchLoading] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
+  const [analyzeError, setAnalyzeError] = useState<string | null>(null);
 
   // fashion은 2뎁스 미사용 → 1뎁스로 되돌림
   useEffect(() => {
@@ -107,6 +108,7 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
   const isReady = selectionCount >= 3;
 
   const handleAnalyze = async () => {
+    setAnalyzeError(null);
     try {
       const request = buildInferenceRequest({
         domain,
@@ -119,8 +121,7 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
       saveResult(result);
       router.push(`/result/${result.id}`);
     } catch (e) {
-      console.error(e);
-      alert(e instanceof Error ? e.message : "분석에 실패했습니다.");
+      setAnalyzeError(e instanceof Error ? e.message : "분석에 실패했습니다.");
     }
   };
 
@@ -155,6 +156,8 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
         onSearchChange={setSearchQuery}
         isNextDisabled={!isReady || isAnalyzing}
         onNext={handleAnalyze}
+        nextLabel={isAnalyzing ? "분석 중..." : undefined}
+        errorMessage={analyzeError}
         selectionCount={selectionCount}
       >
         <div className="grid-cols-responsive">

--- a/src/app/taste/[domain]/page.tsx
+++ b/src/app/taste/[domain]/page.tsx
@@ -1,11 +1,18 @@
 "use client";
 
+import { useCallback, useState } from "react";
+
+import { useRouter } from "next/navigation";
+
 import { DomainGuard } from "@/components/domain/DomainGuard";
 import { FashionInput } from "@/components/domain/fashionInput";
 import { MovieInput } from "@/components/domain/movieInput";
 import { MusicInput } from "@/components/domain/musicInput";
 import { BottomNav } from "@/components/layout/BottomNav";
 import { ProgressBar } from "@/components/layout/ProgressBar";
+import { useInference } from "@/hooks/useInference";
+import { buildInferenceRequest } from "@/lib/inference/normalizeRequest";
+import { useResultStore } from "@/store/resultStore";
 import { useTasteStore } from "@/store/tasteStore";
 import type { Domain } from "@/types/taste";
 
@@ -28,21 +35,50 @@ const DOMAIN_CONTENT: Record<Domain, { titleMain: string; description: string }>
   },
 };
 
-// TODO: 실제 분석 resultId로 교체 (현재 mock 매칭용)
-const RESULT_PATH = "/result/mock-1";
-
 export default function TasteStep1Page({ params }: ITastePageProps) {
+  const router = useRouter();
   const domain = params.domain as Domain;
   const content = DOMAIN_CONTENT[domain];
 
-  // 1뎁스 스타일 선택 여부로 다음 버튼 활성화
   const selectedStyles = useTasteStore((s) => s.selectedStyles);
+  const musicSelections = useTasteStore((s) => s.musicSelections);
+  const movieSelections = useTasteStore((s) => s.movieSelections);
+  const fashionSelections = useTasteStore((s) => s.fashionSelections);
   const isStyleSelected = Boolean(selectedStyles[domain]);
 
-  // fashion은 detail(2뎁스) 없이 결과로 직행
+  const saveResult = useResultStore((s) => s.saveResult);
+  const { infer, isLoading: isAnalyzing } = useInference();
+
+  const [analyzeError, setAnalyzeError] = useState<string | null>(null);
+
   const isFashion = domain === "fashion";
-  const nextPath = isFashion ? RESULT_PATH : `/taste/${domain}/detail`;
   const totalSteps = isFashion ? 1 : 2;
+
+  const handleFashionAnalyze = useCallback(async () => {
+    setAnalyzeError(null);
+    try {
+      const request = buildInferenceRequest({
+        domain: "fashion",
+        musicSelections,
+        movieSelections,
+        fashionSelections,
+        selectedStyles,
+      });
+      const result = await infer(request);
+      saveResult(result);
+      router.push(`/result/${result.id}`);
+    } catch (e) {
+      setAnalyzeError(e instanceof Error ? e.message : "분석에 실패했습니다.");
+    }
+  }, [
+    musicSelections,
+    movieSelections,
+    fashionSelections,
+    selectedStyles,
+    infer,
+    saveResult,
+    router,
+  ]);
 
   return (
     <DomainGuard domain={params.domain}>
@@ -63,7 +99,23 @@ export default function TasteStep1Page({ params }: ITastePageProps) {
           {domain === "fashion" && <FashionInput />}
         </section>
 
-        <BottomNav prevPath="/select" nextPath={nextPath} isNextDisabled={!isStyleSelected} />
+        {analyzeError && <p className="mb-4 text-center text-sm text-red-400">{analyzeError}</p>}
+
+        {isFashion ? (
+          <BottomNav
+            prevPath="/select"
+            isNextDisabled={!isStyleSelected || isAnalyzing}
+            onNext={handleFashionAnalyze}
+            nextLabel={isAnalyzing ? "분석 중..." : "스타일 분석 시작하기"}
+            isLastStep
+          />
+        ) : (
+          <BottomNav
+            prevPath="/select"
+            nextPath={`/taste/${domain}/detail`}
+            isNextDisabled={!isStyleSelected}
+          />
+        )}
       </div>
     </DomainGuard>
   );

--- a/src/components/domain/tasteInputForm/TasteInputForm.tsx
+++ b/src/components/domain/tasteInputForm/TasteInputForm.tsx
@@ -38,6 +38,8 @@ export function TasteInputForm({
   children,
   isNextDisabled,
   onNext,
+  nextLabel,
+  errorMessage,
   selectionCount,
   maxSelections = 3,
 }: ITasteInputFormProps) {
@@ -97,10 +99,12 @@ export function TasteInputForm({
         </p>
       )}
 
+      {errorMessage && <p className="mb-4 text-center text-sm text-red-400">{errorMessage}</p>}
+
       <BottomNav
         prevPath={`/taste/${domain}`}
         prevLabel="이전으로"
-        nextLabel="스타일 분석 시작하기"
+        nextLabel={nextLabel ?? "스타일 분석 시작하기"}
         isNextDisabled={isNextDisabled}
         onNext={onNext}
         isLastStep

--- a/src/components/domain/tasteInputForm/tasteInputForm.types.ts
+++ b/src/components/domain/tasteInputForm/tasteInputForm.types.ts
@@ -15,6 +15,8 @@ export interface ITasteInputFormProps {
 
   isNextDisabled?: boolean;
   onNext?: () => void;
+  nextLabel?: string;
+  errorMessage?: string | null;
 
   selectionCount?: number;
   maxSelections?: number;


### PR DESCRIPTION
## Summary

- **[Critical] 패션 E2E 완전 파괴 수정 (#140)**: `RESULT_PATH = "/result/mock-1"` 하드코딩 제거 — 패션 1뎁스 페이지에서 inference API를 호출하지 않고 존재하지 않는 결과 경로로 이동하던 버그. `handleFashionAnalyze` 추가하여 music/movie와 동일한 분석 플로우 연결
- **분석 실패 에러 UI 개선 (#138 #139 #141)**: `alert()` 제거, 인라인 에러 메시지 표시로 교체. `TasteInputForm`에 `errorMessage`, `nextLabel` props 추가
- **분석 중 버튼 상태 (#138 #139 #140)**: `isAnalyzing` 시 버튼 비활성화 + "분석 중..." 레이블 표시
- **모바일 레이아웃 (#142)**: 코드 점검 완료 — `page-container`, `grid-cols-responsive`, `overflow-x-auto` 패턴 정상 적용 확인. 코드 수정 없음

## QA 점검 항목

| 이슈 | 시나리오 | 결과 |
|---|---|---|
| #138 음악 E2E | `/select` → `/taste/music` → 아티스트 3개 선택 → 분석 → `/result/{id}` | OK — 플로우 정상 |
| #139 영화 E2E | `/select` → `/taste/movie` → 영화 3개 선택 → 분석 → `/result/{id}` | OK — 플로우 정상 |
| #140 패션 E2E | `/select` → `/taste/fashion` → 스타일 선택 → 분석 → `/result/{id}` | **FIXED** — 버그 수정 |
| #141 API 실패 fallback | Grok 오류 시 에러 메시지 표시 | **FIXED** — 인라인 UI 개선 |
| #142 모바일 레이아웃 | 390px 기준 레이아웃, 카드 가로 스크롤 | OK — 수정 불필요 |

## Test plan

- [ ] `/taste/fashion` → 스타일 선택 후 "스타일 분석 시작하기" 클릭 → inference API 호출 → `/result/{id}` 이동 확인
- [ ] API 실패 시 (GROK_API_KEY 없는 환경) 에러 메시지 인라인 노출 확인
- [ ] `isAnalyzing` 중 버튼 비활성화 + "분석 중..." 레이블 확인
- [ ] music/movie 기존 플로우 회귀 없음 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKLhaEPP1Lh7CdfhcFsNY7