### PR TITLE
fix: closes #258 InputSummary × 버튼 히트 영역 수정

### DIFF
--- a/src/components/domain/inputSummary/InputSummary.tsx
+++ b/src/components/domain/inputSummary/InputSummary.tsx
@@ -20,15 +20,17 @@ export function InputSummary({ items, onRemove, label }: IInputSummaryProps) {
             key={item.id}
             className="relative flex w-16 flex-shrink-0 flex-col items-center gap-1.5"
           >
-            <div className="relative h-14 w-14 overflow-hidden rounded-full bg-surface-variant">
-              {item.imageUrl && (
-                <Image src={item.imageUrl} alt={item.name} fill className="object-cover" />
-              )}
+            <div className="relative h-14 w-14">
+              <div className="h-full w-full overflow-hidden rounded-full bg-surface-variant">
+                {item.imageUrl && (
+                  <Image src={item.imageUrl} alt={item.name} fill className="object-cover" />
+                )}
+              </div>
               <button
                 type="button"
                 onClick={() => onRemove(item.id)}
                 aria-label={`${item.name} 선택 해제`}
-                className="absolute -right-0.5 -top-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-primary-container text-xs leading-none text-white shadow-sm"
+                className="absolute -right-0.5 top-0 flex h-5 w-5 items-center justify-center rounded-full bg-primary-container text-xs leading-none text-white shadow-sm"
               >
                 ×
               </button>


### PR DESCRIPTION
## Summary

`InputSummary` 컴포넌트에서 × 버튼이 `overflow-hidden rounded-full` 부모 안에 배치되어 원형 클립에 의해 클릭 가능 영역이 ~25%로 제한되던 버그 수정.

**원인**: 버튼 중심이 `h-14 w-14` 원형 컨테이너(반지름 28px) 경계 밖에 위치 → `overflow: hidden`이 렌더링과 pointer events 동시에 clip

**수정**: 이미지 컨테이너(`overflow-hidden rounded-full`)와 × 버튼을 분리. 버튼을 외부 `relative h-14 w-14` div에 배치하여 히트 영역 100% 확보.

```tsx
// Before — 버튼이 overflow-hidden 내부 (히트 영역 ~25%)
<div className="relative h-14 w-14 overflow-hidden rounded-full ...">
  <Image ... />
  <button className="absolute -right-0.5 -top-0.5 ...">×</button>
</div>

// After — 버튼이 overflow-hidden 외부 (히트 영역 100%)
<div className="relative h-14 w-14">
  <div className="h-full w-full overflow-hidden rounded-full ...">
    <Image ... />
  </div>
  <button className="absolute -right-0.5 top-0 ...">×</button>
</div>
```

## Test plan

- [ ] 아티스트/영화 선택 후 × 버튼 전체 영역 클릭 가능 확인
- [ ] 원형 이미지 클립 정상 유지 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)