### PR TITLE
feat: closes #92 결과 페이지 공유 기능 연결 — Web Share API, Twitter, 재분석

### DIFF
--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { useRouter } from "next/navigation";
 
@@ -11,6 +11,7 @@ import { StyleLabelHero } from "@/components/result/styleLabel";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/Icon";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
+import { useAuthSessionStore } from "@/store/authSessionStore";
 import { useResultStore } from "@/store/resultStore";
 import { useTasteStore } from "@/store/tasteStore";
 
@@ -30,6 +31,9 @@ export default function ResultPage({ params }: IResultPageProps) {
   const result = useResultStore((s) => s.results[params.id]);
   const resetTaste = useTasteStore((s) => s.reset);
 
+  const isAuthenticated = useAuthSessionStore((s) => s.isAuthenticated);
+  const loginBannerRef = useRef<HTMLElement>(null);
+
   const { playingUrl, isPlaying: isAudioPlaying, toggle } = useAudioPlayer();
   const [shareCopied, setShareCopied] = useState(false);
 
@@ -39,6 +43,10 @@ export default function ResultPage({ params }: IResultPageProps) {
   }, [resetTaste, router]);
 
   const handleShareCard = useCallback(async () => {
+    if (!isAuthenticated) {
+      loginBannerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
+    }
     const shareData = {
       title: result ? `${result.styleLabel.title} — StyleSync` : "StyleSync",
       text: result?.styleLabel.description ?? "나만의 크로스 도메인 스타일을 확인해보세요.",
@@ -55,7 +63,7 @@ export default function ResultPage({ params }: IResultPageProps) {
     await navigator.clipboard.writeText(window.location.href);
     setShareCopied(true);
     setTimeout(() => setShareCopied(false), 2000);
-  }, [result]);
+  }, [isAuthenticated, result]);
 
   if (!result) {
     return <ResultPageError message="결과를 찾을 수 없어요. 다시 분석해 주세요." />;
@@ -222,7 +230,10 @@ export default function ResultPage({ params }: IResultPageProps) {
         </section>
 
         {/* ── Guest Save Banner ─────────────────────────────────────────────── */}
-        <section className="flex flex-col items-center gap-4 text-center bg-surface-variant rounded-[24px] px-8 py-8 md:flex-row md:items-center md:justify-between md:text-left md:py-0 md:h-[116px]">
+        <section
+          ref={loginBannerRef}
+          className="flex flex-col items-center gap-4 text-center bg-surface-variant rounded-[24px] px-8 py-8 md:flex-row md:items-center md:justify-between md:text-left md:py-0 md:h-[116px]"
+        >
           <div className="flex flex-col items-center gap-2 md:flex-row md:gap-3">
             <span className="text-[24px]" aria-hidden="true">
               ✨

--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
+
+import { useRouter } from "next/navigation";
 
 import { RecommendCard } from "@/components/result/recommendCard";
 import { ResultPageError } from "@/components/result/ResultPageError";
@@ -10,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/Icon";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
 import { useResultStore } from "@/store/resultStore";
+import { useTasteStore } from "@/store/tasteStore";
 
 // X(Twitter) 아이콘 — Icon 레지스트리에 없어서 인라인 처리
 const XIcon = () => (
@@ -23,17 +26,36 @@ interface IResultPageProps {
 }
 
 export default function ResultPage({ params }: IResultPageProps) {
+  const router = useRouter();
   const result = useResultStore((s) => s.results[params.id]);
+  const resetTaste = useTasteStore((s) => s.reset);
 
   const { playingUrl, isPlaying: isAudioPlaying, toggle } = useAudioPlayer();
+  const [shareCopied, setShareCopied] = useState(false);
 
   const handleReanalyze = useCallback(() => {
-    // TODO: 재분석 플로우 연결
-  }, []);
+    resetTaste();
+    router.push("/select");
+  }, [resetTaste, router]);
 
-  const handleShareCard = useCallback(() => {
-    // TODO: 공유 카드 모달 연결
-  }, []);
+  const handleShareCard = useCallback(async () => {
+    const shareData = {
+      title: result ? `${result.styleLabel.title} — StyleSync` : "StyleSync",
+      text: result?.styleLabel.description ?? "나만의 크로스 도메인 스타일을 확인해보세요.",
+      url: window.location.href,
+    };
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch {
+        // 사용자 취소 시 무시
+      }
+    }
+    await navigator.clipboard.writeText(window.location.href);
+    setShareCopied(true);
+    setTimeout(() => setShareCopied(false), 2000);
+  }, [result]);
 
   if (!result) {
     return <ResultPageError message="결과를 찾을 수 없어요. 다시 분석해 주세요." />;
@@ -154,10 +176,26 @@ export default function ResultPage({ params }: IResultPageProps) {
                   size="sm"
                   icon={<Icon name="instagram" size={20} />}
                   iconPosition="left"
+                  onClick={handleShareCard}
                 >
-                  Instagram 공유
+                  {shareCopied ? "링크 복사됨!" : "Instagram 공유"}
                 </Button>
-                <Button variant="dark" size="sm" icon={<XIcon />} iconPosition="left">
+                <Button
+                  variant="dark"
+                  size="sm"
+                  icon={<XIcon />}
+                  iconPosition="left"
+                  onClick={() => {
+                    const text = result
+                      ? `${result.styleLabel.title}\n${result.styleLabel.description} #StyleSync`
+                      : "#StyleSync";
+                    window.open(
+                      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(window.location.href)}`,
+                      "_blank",
+                      "noopener,noreferrer"
+                    );
+                  }}
+                >
                   Twitter 공유
                 </Button>
               </div>


### PR DESCRIPTION
## Summary

결과 페이지의 미연결 버튼들을 실제 기능에 연결.

- **재분석 버튼** (`handleReanalyze`): `tasteStore.reset()` 후 `/select` 이동
- **공유 카드 만들기 / Instagram 공유** (`handleShareCard`): Web Share API 지원 환경에서 네이티브 공유 다이얼로그, 미지원 시 URL 클립보드 복사 + "링크 복사됨!" 2초 피드백
- **Twitter 공유**: `twitter.com/intent/tweet`으로 스타일 레이블 텍스트 + URL 전달

## 동작 상세

| 버튼 | 지원 환경 | 미지원 환경 |
|------|----------|------------|
| Instagram 공유 | `navigator.share()` 네이티브 공유 | URL 클립보드 복사 |
| Twitter 공유 | `twitter.com/intent/tweet` 새 탭 | (동일) |
| 공유 카드 만들기 | `navigator.share()` 네이티브 공유 | URL 클립보드 복사 |
| 다시 분석하기 | `tasteStore.reset()` → `/select` | — |

## Test plan

- [ ] "다시 분석하기" 클릭 → `/select` 이동 + 이전 선택 초기화 확인
- [ ] 모바일(Chrome/Safari) — "공유 카드 만들기" → 네이티브 공유 시트 확인
- [ ] 데스크탑 — "Instagram 공유" → "링크 복사됨!" 피드백 확인
- [ ] "Twitter 공유" → `twitter.com/intent/tweet` 새 탭 + 스타일 레이블 텍스트 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)