### PR TITLE
chore: closes #268 ProgressBar → StepIndicator 디자인 시스템 컴포넌트로 교체

### DIFF
--- a/src/app/taste/[domain]/page.tsx
+++ b/src/app/taste/[domain]/page.tsx
@@ -9,7 +9,7 @@ import { FashionInput } from "@/components/domain/fashionInput";
 import { MovieInput } from "@/components/domain/movieInput";
 import { MusicInput } from "@/components/domain/musicInput";
 import { BottomNav } from "@/components/layout/BottomNav";
-import { ProgressBar } from "@/components/layout/ProgressBar";
+import { StepIndicator } from "@/components/ui/StepIndicator";
 import { useInference } from "@/hooks/useInference";
 import { buildInferenceRequest } from "@/lib/inference/normalizeRequest";
 import { useResultStore } from "@/store/resultStore";
@@ -90,7 +90,7 @@ export default function TasteStep1Page({ params }: ITastePageProps) {
             </h1>
             <p className="type-body-lg keep-all text-on-surface-variant">{content?.description}</p>
           </div>
-          <ProgressBar currentStep={1} totalSteps={totalSteps} />
+          <StepIndicator current={1} total={totalSteps} />
         </header>
 
         <section className="min-h-[60vh]">

--- a/src/components/domain/tasteInputForm/TasteInputForm.tsx
+++ b/src/components/domain/tasteInputForm/TasteInputForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { BottomNav } from "@/components/layout/BottomNav";
-import { ProgressBar } from "@/components/layout/ProgressBar";
+import { StepIndicator } from "@/components/ui/StepIndicator";
 
 import type { ITasteInputFormProps } from "./tasteInputForm.types";
 
@@ -57,7 +57,7 @@ export function TasteInputForm({
           <p className="type-body-lg text-stone-600">{description}</p>
         </div>
 
-        <ProgressBar currentStep={2} totalSteps={2} />
+        <StepIndicator current={2} total={2} />
       </header>
 
       {/* 


### PR DESCRIPTION
## Summary

임시 구현체 `ProgressBar`를 디자인 시스템 `StepIndicator`로 교체. `ProgressBar` 컴포넌트 코드 내 TODO에 명시된 후속 작업.

## 변경 내용

| 파일 | 변경 |
|------|------|
| `src/app/taste/[domain]/page.tsx` | `<ProgressBar currentStep={1} totalSteps={totalSteps} />` → `<StepIndicator current={1} total={totalSteps} />` |
| `src/components/domain/tasteInputForm/TasteInputForm.tsx` | `<ProgressBar currentStep={2} totalSteps={2} />` → `<StepIndicator current={2} total={2} />` |

## Test plan

- [ ] 음악/영화/패션 도메인 취향 입력 Step 1 — 스텝 인디케이터 "1/2" 표시 확인
- [ ] 취향 상세 입력 Step 2 — "2/2" + 프로그레스 바 100% 확인
- [ ] 패션 도메인 Step 1 — "1/1" 표시 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)