### PR TITLE
chore: closes #274 빈 스텁 파일 3개 삭제

### DIFF
--- a/src/hooks/useSpotify.ts
+++ b/src/hooks/useSpotify.ts
@@ -1,4 +1,0 @@
-// TODO: Spotify API 훅
-export function useSpotify() {
-  return {};
-}

--- a/src/hooks/useTMDB.ts
+++ b/src/hooks/useTMDB.ts
@@ -1,4 +1,0 @@
-// TODO: TMDB API 훅
-export function useTMDB() {
-  return {};
-}

--- a/src/lib/fashion.ts
+++ b/src/lib/fashion.ts
@@ -1,2 +1,0 @@
-// TODO: Google Custom Search (패션 이미지)
-export {};


### PR DESCRIPTION
## Summary

초기 기획 단계 스텁으로 남아 있던 파일 3개 삭제.

| 파일 | 이유 |
|------|------|
| `src/hooks/useSpotify.ts` | 서버사이드 `/api/spotify` 라우트로 대체 완료 |
| `src/hooks/useTMDB.ts` | 서버사이드 `/api/tmdb` 라우트로 대체 완료 |
| `src/lib/fashion.ts` | Unsplash 연동(#224/#244)으로 대체 완료 |

```bash
git grep -l "useSpotify\|useTMDB\|from.*lib/fashion" -- "*.tsx" "*.ts"
# 파일 자체만 나옴 (import 없음 확인)
```

## Test plan

- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)