### PR TITLE
chore: closes #276 taste 플로우 파일 소규모 정리

### DIFF
--- a/src/app/taste/layout.tsx
+++ b/src/app/taste/layout.tsx
@@ -1,18 +1,3 @@
 export default function TasteLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;
 }
-
-// import { StepIndicator } from '@/components/ui/StepIndicator';
-
-// export default function TasteLayout({ children }: { children: React.ReactNode }) {
-//   return (
-//     <div className="flex flex-col">
-//       {/* TODO: 현재 페이지에 따라 step 값 동적으로 계산해서 넣기 (usePathname 활용) */}
-//       <header className="p-4">
-//         <StepIndicator current={1} total={2} fullWidth />
-//       </header>
-
-//       {children}
-//     </div>
-//   );
-// }

--- a/src/components/domain/tasteInputForm/TasteInputForm.tsx
+++ b/src/components/domain/tasteInputForm/TasteInputForm.tsx
@@ -1,27 +1,10 @@
 "use client";
 
 import { BottomNav } from "@/components/layout/BottomNav";
+import { Icon } from "@/components/ui/Icon";
 import { StepIndicator } from "@/components/ui/StepIndicator";
 
 import type { ITasteInputFormProps } from "./tasteInputForm.types";
-
-// TODO: 디자인 시스템 Icon 세트로 교체 필요
-// (lucide-react 등 공용 라이브러리 사용 가능)
-const SearchIcon = () => (
-  <svg
-    width="20"
-    height="20"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="11" cy="11" r="8" />
-    <path d="m21 21-4.3-4.3" />
-  </svg>
-);
 
 function getSelectionMessage(count: number, max: number): { text: string; done: boolean } {
   if (count >= max) return { text: "완벽해요! 분석을 시작할게요", done: true };
@@ -75,7 +58,7 @@ export function TasteInputForm({
       {/* 검색바 */}
       <div className="relative mb-8 w-full">
         <div className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-stone-400">
-          <SearchIcon />
+          <Icon name="search" size={20} />
         </div>
 
         <input


### PR DESCRIPTION
## Summary

두 가지 minor 정리.

**`TasteInputForm.tsx`**
- 인라인 `SearchIcon` SVG 컴포넌트 제거
- `Icon name="search"` (디자인 시스템 Icon 레지스트리에 등록된 아이콘)으로 교체
- 관련 TODO 주석 제거

**`taste/layout.tsx`**
- 각 taste 페이지가 자체 `StepIndicator`를 갖게 되면서 불필요해진 주석 처리 코드 블록 삭제

## Test plan

- [ ] 취향 상세 입력 화면 검색바 아이콘 정상 표시 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)