### PR TITLE
feat: closes #106 #108 결과 저장 API + 저장 상태 배너 구현

### DIFF
--- a/src/app/api/results/route.ts
+++ b/src/app/api/results/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import type { StyleResult } from "@/types/result";
+import type { Domain } from "@/types/taste";
+
+type SaveResultBody = {
+  result: StyleResult;
+  startDomain: Domain;
+  requestPayload: unknown;
+};
+
+export async function POST(req: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  let body: SaveResultBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  const { result, startDomain, requestPayload } = body;
+
+  if (!result?.id || !startDomain) {
+    return NextResponse.json({ error: "필수 필드가 누락됐습니다." }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from("results")
+    .insert({
+      id: result.id,
+      profile_id: user.id,
+      start_domain: startDomain,
+      request_payload: requestPayload ?? {},
+      result_payload: result,
+      style_label: result.styleLabel,
+      music_recommendations: result.music,
+      movie_recommendations: result.movie,
+      fashion_recommendations: result.fashion,
+      is_public: true,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    // 이미 저장된 결과 (unique violation) — 멱등 처리
+    if (error.code === "23505") {
+      return NextResponse.json({ id: result.id });
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ id: data.id }, { status: 201 });
+}

--- a/src/app/api/results/route.ts
+++ b/src/app/api/results/route.ts
@@ -47,7 +47,9 @@ export async function POST(req: NextRequest) {
       music_recommendations: result.music,
       movie_recommendations: result.movie,
       fashion_recommendations: result.fashion,
-      is_public: true,
+      // 기본 비공개 — 저장 시점엔 본인만 볼 수 있고, 공유는 별도 액션에서 명시적으로 공개 전환한다.
+      // (#97 "저장 데이터는 해당 사용자만 볼 수 있다")
+      is_public: false,
     })
     .select("id")
     .single();

--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -29,6 +29,7 @@ interface IResultPageProps {
 export default function ResultPage({ params }: IResultPageProps) {
   const router = useRouter();
   const result = useResultStore((s) => s.results[params.id]);
+  const saveStatus = useResultStore((s) => s.saveStatuses[params.id]);
   const resetTaste = useTasteStore((s) => s.reset);
 
   const isAuthenticated = useAuthSessionStore((s) => s.isAuthenticated);
@@ -234,17 +235,23 @@ export default function ResultPage({ params }: IResultPageProps) {
           <section className="flex flex-col items-center gap-4 text-center bg-surface-variant rounded-[24px] px-8 py-8 md:flex-row md:items-center md:justify-between md:text-left md:py-0 md:h-[116px]">
             <div className="flex flex-col items-center gap-2 md:flex-row md:gap-3">
               <span className="text-[24px]" aria-hidden="true">
-                ✅
+                {saveStatus === "error" ? "⚠️" : saveStatus === "saving" ? "⏳" : "✅"}
               </span>
               <p className="font-korean font-normal text-body-lg text-on-background keep-all">
-                분석 결과가 히스토리에 저장됐어요. 마이 페이지에서 다시 확인할 수 있어요.
+                {saveStatus === "error"
+                  ? "결과 저장에 실패했어요. 네트워크 상태를 확인하고 다시 시도해주세요."
+                  : saveStatus === "saving"
+                    ? "분석 결과를 저장하고 있어요..."
+                    : "분석 결과가 히스토리에 저장됐어요. 마이 페이지에서 다시 확인할 수 있어요."}
               </p>
             </div>
-            <div className="flex items-center gap-3 flex-shrink-0">
-              <Button variant="dark" size="sm" onClick={() => router.push("/profile")}>
-                히스토리 보기
-              </Button>
-            </div>
+            {saveStatus !== "error" && (
+              <div className="flex items-center gap-3 flex-shrink-0">
+                <Button variant="dark" size="sm" onClick={() => router.push("/profile")}>
+                  히스토리 보기
+                </Button>
+              </div>
+            )}
           </section>
         ) : (
           <section

--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -229,28 +229,46 @@ export default function ResultPage({ params }: IResultPageProps) {
           </div>
         </section>
 
-        {/* ── Guest Save Banner ─────────────────────────────────────────────── */}
-        <section
-          ref={loginBannerRef}
-          className="flex flex-col items-center gap-4 text-center bg-surface-variant rounded-[24px] px-8 py-8 md:flex-row md:items-center md:justify-between md:text-left md:py-0 md:h-[116px]"
-        >
-          <div className="flex flex-col items-center gap-2 md:flex-row md:gap-3">
-            <span className="text-[24px]" aria-hidden="true">
-              ✨
-            </span>
-            <p className="font-korean font-normal text-body-lg text-on-background keep-all">
-              결과를 저장하고 싶다면? 로그인하면 나만의 스타일 히스토리를 쌓을 수 있어요.
-            </p>
-          </div>
-          <div className="flex items-center gap-3 flex-shrink-0">
-            <Button variant="dark" size="sm">
-              Google로 시작하기
-            </Button>
-            <Button variant="ghost" size="sm">
-              나중에 할게요 →
-            </Button>
-          </div>
-        </section>
+        {/* ── Save Banner ───────────────────────────────────────────────────── */}
+        {isAuthenticated ? (
+          <section className="flex flex-col items-center gap-4 text-center bg-surface-variant rounded-[24px] px-8 py-8 md:flex-row md:items-center md:justify-between md:text-left md:py-0 md:h-[116px]">
+            <div className="flex flex-col items-center gap-2 md:flex-row md:gap-3">
+              <span className="text-[24px]" aria-hidden="true">
+                ✅
+              </span>
+              <p className="font-korean font-normal text-body-lg text-on-background keep-all">
+                분석 결과가 히스토리에 저장됐어요. 마이 페이지에서 다시 확인할 수 있어요.
+              </p>
+            </div>
+            <div className="flex items-center gap-3 flex-shrink-0">
+              <Button variant="dark" size="sm" onClick={() => router.push("/profile")}>
+                히스토리 보기
+              </Button>
+            </div>
+          </section>
+        ) : (
+          <section
+            ref={loginBannerRef}
+            className="flex flex-col items-center gap-4 text-center bg-surface-variant rounded-[24px] px-8 py-8 md:flex-row md:items-center md:justify-between md:text-left md:py-0 md:h-[116px]"
+          >
+            <div className="flex flex-col items-center gap-2 md:flex-row md:gap-3">
+              <span className="text-[24px]" aria-hidden="true">
+                ✨
+              </span>
+              <p className="font-korean font-normal text-body-lg text-on-background keep-all">
+                결과를 저장하고 싶다면? 로그인하면 나만의 스타일 히스토리를 쌓을 수 있어요.
+              </p>
+            </div>
+            <div className="flex items-center gap-3 flex-shrink-0">
+              <Button variant="dark" size="sm" onClick={() => router.push("/login")}>
+                Google로 시작하기
+              </Button>
+              <Button variant="ghost" size="sm">
+                나중에 할게요 →
+              </Button>
+            </div>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -11,6 +11,7 @@ import { MusicTasteCard } from "@/components/domain/musicTasteCard";
 import { TasteInputForm } from "@/components/domain/tasteInputForm";
 import { useInference } from "@/hooks/useInference";
 import { buildInferenceRequest } from "@/lib/inference/normalizeRequest";
+import { useAuthSessionStore } from "@/store/authSessionStore";
 import { useResultStore } from "@/store/resultStore";
 import { useTasteStore } from "@/store/tasteStore";
 import type { Domain, MovieSelection, MusicSelection } from "@/types/taste";
@@ -52,6 +53,7 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
   const fashionSelections = useTasteStore((s) => s.fashionSelections);
   const selectedStyles = useTasteStore((s) => s.selectedStyles);
   const saveResult = useResultStore((s) => s.saveResult);
+  const isAuthenticated = useAuthSessionStore((s) => s.isAuthenticated);
   const { infer, isLoading: isAnalyzing } = useInference();
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -120,6 +122,13 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
       });
       const result = await infer(request);
       saveResult(result);
+      if (isAuthenticated) {
+        fetch("/api/results", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ result, startDomain: domain, requestPayload: request }),
+        }).catch(() => {});
+      }
       router.push(`/result/${result.id}`);
     } catch (e) {
       setAnalyzeError(e instanceof Error ? e.message : "분석에 실패했습니다.");

--- a/src/app/taste/[domain]/detail/page.tsx
+++ b/src/app/taste/[domain]/detail/page.tsx
@@ -53,6 +53,7 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
   const fashionSelections = useTasteStore((s) => s.fashionSelections);
   const selectedStyles = useTasteStore((s) => s.selectedStyles);
   const saveResult = useResultStore((s) => s.saveResult);
+  const setSaveStatus = useResultStore((s) => s.setSaveStatus);
   const isAuthenticated = useAuthSessionStore((s) => s.isAuthenticated);
   const { infer, isLoading: isAnalyzing } = useInference();
 
@@ -123,11 +124,14 @@ export default function TasteStep2Page({ params }: ITasteDetailPageProps) {
       const result = await infer(request);
       saveResult(result);
       if (isAuthenticated) {
+        setSaveStatus(result.id, "saving");
         fetch("/api/results", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ result, startDomain: domain, requestPayload: request }),
-        }).catch(() => {});
+        })
+          .then((res) => setSaveStatus(result.id, res.ok ? "saved" : "error"))
+          .catch(() => setSaveStatus(result.id, "error"));
       }
       router.push(`/result/${result.id}`);
     } catch (e) {

--- a/src/app/taste/[domain]/page.tsx
+++ b/src/app/taste/[domain]/page.tsx
@@ -48,6 +48,7 @@ export default function TasteStep1Page({ params }: ITastePageProps) {
   const isStyleSelected = Boolean(selectedStyles[domain]);
 
   const saveResult = useResultStore((s) => s.saveResult);
+  const setSaveStatus = useResultStore((s) => s.setSaveStatus);
   const isAuthenticated = useAuthSessionStore((s) => s.isAuthenticated);
   const { infer, isLoading: isAnalyzing } = useInference();
 
@@ -69,11 +70,14 @@ export default function TasteStep1Page({ params }: ITastePageProps) {
       const result = await infer(request);
       saveResult(result);
       if (isAuthenticated) {
+        setSaveStatus(result.id, "saving");
         fetch("/api/results", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ result, startDomain: domain, requestPayload: request }),
-        }).catch(() => {});
+        })
+          .then((res) => setSaveStatus(result.id, res.ok ? "saved" : "error"))
+          .catch(() => setSaveStatus(result.id, "error"));
       }
       router.push(`/result/${result.id}`);
     } catch (e) {
@@ -87,6 +91,7 @@ export default function TasteStep1Page({ params }: ITastePageProps) {
     selectedStyles,
     infer,
     saveResult,
+    setSaveStatus,
     isAuthenticated,
     router,
   ]);

--- a/src/app/taste/[domain]/page.tsx
+++ b/src/app/taste/[domain]/page.tsx
@@ -12,6 +12,7 @@ import { BottomNav } from "@/components/layout/BottomNav";
 import { StepIndicator } from "@/components/ui/StepIndicator";
 import { useInference } from "@/hooks/useInference";
 import { buildInferenceRequest } from "@/lib/inference/normalizeRequest";
+import { useAuthSessionStore } from "@/store/authSessionStore";
 import { useResultStore } from "@/store/resultStore";
 import { useTasteStore } from "@/store/tasteStore";
 import type { Domain } from "@/types/taste";
@@ -47,6 +48,7 @@ export default function TasteStep1Page({ params }: ITastePageProps) {
   const isStyleSelected = Boolean(selectedStyles[domain]);
 
   const saveResult = useResultStore((s) => s.saveResult);
+  const isAuthenticated = useAuthSessionStore((s) => s.isAuthenticated);
   const { infer, isLoading: isAnalyzing } = useInference();
 
   const [analyzeError, setAnalyzeError] = useState<string | null>(null);
@@ -66,17 +68,26 @@ export default function TasteStep1Page({ params }: ITastePageProps) {
       });
       const result = await infer(request);
       saveResult(result);
+      if (isAuthenticated) {
+        fetch("/api/results", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ result, startDomain: domain, requestPayload: request }),
+        }).catch(() => {});
+      }
       router.push(`/result/${result.id}`);
     } catch (e) {
       setAnalyzeError(e instanceof Error ? e.message : "분석에 실패했습니다.");
     }
   }, [
+    domain,
     musicSelections,
     movieSelections,
     fashionSelections,
     selectedStyles,
     infer,
     saveResult,
+    isAuthenticated,
     router,
   ]);
 

--- a/src/store/resultStore.ts
+++ b/src/store/resultStore.ts
@@ -3,9 +3,14 @@ import { persist, createJSONStorage } from "zustand/middleware";
 
 import type { StyleResult } from "@/types/result";
 
+/** 결과별 DB 저장 상태. 저장 배너가 실제 결과를 반영하도록 사용한다. */
+export type SaveStatus = "saving" | "saved" | "error";
+
 type ResultStore = {
   results: Record<string, StyleResult>;
+  saveStatuses: Record<string, SaveStatus>;
   saveResult: (result: StyleResult) => void;
+  setSaveStatus: (id: string, status: SaveStatus) => void;
   getResult: (id: string) => StyleResult | undefined;
 };
 
@@ -13,8 +18,11 @@ export const useResultStore = create<ResultStore>()(
   persist(
     (set, get) => ({
       results: {},
+      saveStatuses: {},
       saveResult: (result) =>
         set((state) => ({ results: { ...state.results, [result.id]: result } })),
+      setSaveStatus: (id, status) =>
+        set((state) => ({ saveStatuses: { ...state.saveStatuses, [id]: status } })),
       getResult: (id) => get().results[id],
     }),
     {


### PR DESCRIPTION
## Summary

분석 결과를 Supabase `results` 테이블에 저장하는 API와 결과 페이지 저장 상태 배너를 구현합니다.

**`POST /api/results`** (신설)
- 로그인 확인(`supabase.auth.getUser()`) — 미인증 시 401
- `results` 테이블 insert: `style_label`, `music/movie/fashion_recommendations`, `request_payload`, `start_domain` 포함
- 중복 저장(unique violation `23505`) 멱등 처리 — 같은 `result.id` 재전송 시 200으로 응답

**분석 완료 → 자동 저장** (`taste/[domain]/page.tsx`, `detail/page.tsx`)
- `isAuthenticated` 확인 후 `fetch("/api/results", ...)` fire-and-forget
- 저장 실패해도 분석 결과 페이지 이동은 영향 없음

**결과 페이지 하단 배너** (`result/[id]/page.tsx`)
- 비로그인: 기존 "Google로 시작하기 / 나중에 할게요" 유지, 로그인 버튼에 `onClick={() => router.push("/login")}` 연결
- 로그인: "분석 결과가 히스토리에 저장됐어요. 마이 페이지에서 다시 확인할 수 있어요." + "히스토리 보기" 버튼

## Test plan

- [ ] 비로그인 상태로 분석 완료 → 결과 페이지 하단 "Google로 시작하기" 배너 표시 확인
- [ ] 로그인 상태로 분석 완료 → 결과 페이지 하단 "히스토리에 저장됐어요" 배너 표시 확인
- [ ] Supabase Dashboard에서 `results` 테이블에 row 삽입 확인
- [ ] 같은 결과 재저장 시 500 없이 정상 응답 확인 (멱등)
- [ ] 비로그인 상태에서 `POST /api/results` 직접 호출 → 401 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #106
closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)