### PR TITLE
feat: closes #97 결과 DB fallback — 세션 만료 후 히스토리에서 재접근 가능

### DIFF
--- a/src/app/api/results/[id]/route.ts
+++ b/src/app/api/results/[id]/route.ts
@@ -7,12 +7,23 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
 
   const { data, error } = await supabase
     .from("results")
-    .select("result_payload")
+    .select("result_payload, profile_id, is_public")
     .eq("id", params.id)
     .single();
 
   if (error || !data?.result_payload) {
     return NextResponse.json({ error: "결과를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  // 접근 제어: 공개 결과가 아니면 본인 소유일 때만 반환한다.
+  // (RLS와 별개로 앱 레벨에서도 명시적으로 차단 — 존재 노출 방지를 위해 403 대신 404)
+  if (!data.is_public) {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user || user.id !== data.profile_id) {
+      return NextResponse.json({ error: "결과를 찾을 수 없습니다." }, { status: 404 });
+    }
   }
 
   return NextResponse.json({ result: data.result_payload });

--- a/src/app/api/results/[id]/route.ts
+++ b/src/app/api/results/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = await createSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from("results")
+    .select("result_payload")
+    .eq("id", params.id)
+    .single();
+
+  if (error || !data?.result_payload) {
+    return NextResponse.json({ error: "결과를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  return NextResponse.json({ result: data.result_payload });
+}

--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useRouter } from "next/navigation";
 
@@ -30,6 +30,7 @@ export default function ResultPage({ params }: IResultPageProps) {
   const router = useRouter();
   const result = useResultStore((s) => s.results[params.id]);
   const saveStatus = useResultStore((s) => s.saveStatuses[params.id]);
+  const saveResult = useResultStore((s) => s.saveResult);
   const resetTaste = useTasteStore((s) => s.reset);
 
   const isAuthenticated = useAuthSessionStore((s) => s.isAuthenticated);
@@ -37,6 +38,22 @@ export default function ResultPage({ params }: IResultPageProps) {
 
   const { playingUrl, isPlaying: isAudioPlaying, toggle } = useAudioPlayer();
   const [shareCopied, setShareCopied] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
+  const [fetchFailed, setFetchFailed] = useState(false);
+
+  // 세션스토리지에 없으면 DB에서 조회
+  useEffect(() => {
+    if (result || isFetching || fetchFailed) return;
+    setIsFetching(true);
+    fetch(`/api/results/${params.id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error();
+        return res.json();
+      })
+      .then((data) => saveResult(data.result))
+      .catch(() => setFetchFailed(true))
+      .finally(() => setIsFetching(false));
+  }, [result, params.id, isFetching, fetchFailed, saveResult]);
 
   const handleReanalyze = useCallback(() => {
     resetTaste();
@@ -67,6 +84,13 @@ export default function ResultPage({ params }: IResultPageProps) {
   }, [isAuthenticated, result]);
 
   if (!result) {
+    if (isFetching) {
+      return (
+        <div className="flex min-h-[60vh] items-center justify-center">
+          <p className="type-body-lg text-on-surface-variant">결과를 불러오는 중...</p>
+        </div>
+      );
+    }
     return <ResultPageError message="결과를 찾을 수 없어요. 다시 분석해 주세요." />;
   }
 


### PR DESCRIPTION
## Summary

결과 페이지(`/result/[id]`)에서 세션스토리지에 결과가 없을 때 Supabase DB에서 읽어오는 fallback을 구현합니다.

**배경**

기존에는 분석 직후 세션스토리지에만 결과가 저장돼 있어, 브라우저를 닫거나 세션이 초기화되면 프로필 히스토리 카드를 클릭해도 "결과를 찾을 수 없어요" 오류가 발생했습니다.

**`GET /api/results/[id]`** (신설)
- `results` 테이블에서 `id` 기준 `result_payload` 단건 조회
- RLS 정책(`results_public_read`, `results_owner_read`) 자동 적용 — 공개 결과 또는 본인 결과만 반환
- 없으면 404

**`result/[id]/page.tsx`** (수정)
- `useEffect`: 스토어에 결과 없고 fetch 중/실패 아닐 때 `GET /api/results/{id}` 호출
- fetch 성공: `saveResult(data.result)` → 스토어에 저장 후 자동 리렌더
- fetch 중: "결과를 불러오는 중..." 로딩 메시지
- fetch 실패: 기존 `ResultPageError` 표시

> **선행 PR**: #278(`POST /api/results`)이 머지되어야 DB에 result_payload가 쌓입니다.

## Test plan

- [ ] 분석 완료 후 브라우저 탭 닫고 재오픈 → `/result/{id}` 직접 접근 → 로딩 후 결과 표시 확인
- [ ] 존재하지 않는 id → "결과를 찾을 수 없어요" 표시 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)