### PR TITLE
feat: closes #129 결과 저장 시 style embedding 생성 및 DB 저장

### DIFF
--- a/src/app/api/results/route.ts
+++ b/src/app/api/results/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { embedText } from "@/lib/grok";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import type { StyleResult } from "@/types/result";
 import type { Domain } from "@/types/taste";
@@ -60,6 +61,21 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ id: result.id });
     }
     return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // best-effort: styleLabel 텍스트를 embedding으로 변환 후 저장
+  // 실패해도 201 응답은 이미 결정됐으므로 무시
+  const embeddingText = [
+    result.styleLabel?.title,
+    result.styleLabel?.description,
+    result.styleLabel?.mood,
+  ]
+    .filter(Boolean)
+    .join(". ");
+
+  const embedding = await embedText(embeddingText);
+  if (embedding) {
+    await supabase.from("results").update({ embedding }).eq("id", data.id);
   }
 
   return NextResponse.json({ id: data.id }, { status: 201 });


### PR DESCRIPTION
## Summary

분석 결과를 DB에 저장할 때 스타일 텍스트를 벡터로 변환하여 함께 저장합니다.

**`src/lib/grok.ts`** (수정)
- `embedText(text)` 추가 — xAI `/v1/embeddings` 호출 (`model: "v1"`)
- 타임아웃/네트워크 오류 발생 시 `null` 반환 (저장 흐름 블로킹 없음)

**`src/app/api/results/route.ts`** (수정)
- INSERT 성공 후 `styleLabel.title + description + mood` 텍스트로 embedding 생성
- `results.embedding` 컬럼에 best-effort `UPDATE` — 실패해도 `201` 응답은 유지

> **선행 PR 의존성**
> - **PR #278** (`POST /api/results` 기본 구현) — 이 PR의 base 브랜치
> - **PR #281** (pgvector 마이그레이션) — `embedding` 컬럼 생성 필요 (없으면 UPDATE silently ignored)

## Test plan

- [ ] 로그인 후 분석 완료 → Supabase `results` 테이블 `embedding` 컬럼에 vector 값 저장 확인
- [ ] xAI embedding API 키 없는 환경에서도 `POST /api/results` → `201` 정상 응답 확인 (null 처리)
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)