### PR TITLE
feat: closes #130 유사도 검색 API — GET /api/results/similar

### DIFF
--- a/src/app/api/results/similar/route.ts
+++ b/src/app/api/results/similar/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  const limit = Math.min(Number(searchParams.get("limit") ?? "10"), 20);
+
+  if (!id) {
+    return NextResponse.json({ error: "id가 필요합니다." }, { status: 400 });
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  const { data, error } = await supabase.rpc("match_results", {
+    target_id: id,
+    match_count: limit,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ results: data ?? [] });
+}

--- a/supabase/migrations/0109_match_results_function.sql
+++ b/supabase/migrations/0109_match_results_function.sql
@@ -1,0 +1,36 @@
+-- #130
+-- 유사도 검색 RPC 함수
+
+create or replace function public.match_results(
+  target_id uuid,
+  match_count int default 10
+)
+returns table (
+  id uuid,
+  style_label jsonb,
+  start_domain text,
+  created_at timestamptz,
+  similarity float
+)
+language sql
+stable
+as $$
+  select
+    r.id,
+    r.style_label,
+    r.start_domain,
+    r.created_at,
+    1 - (r.embedding <=> t.embedding) as similarity
+  from results r
+  join (
+    select embedding
+    from results
+    where id = target_id
+      and embedding is not null
+  ) t on true
+  where r.embedding is not null
+    and r.is_public = true
+    and r.id != target_id
+  order by r.embedding <=> t.embedding
+  limit match_count;
+$$;


### PR DESCRIPTION
## Summary

pgvector 코사인 유사도 기반 유사 결과 검색 API를 구현합니다.

**`supabase/migrations/0109_match_results_function.sql`** (신설)
- `match_results(target_id uuid, match_count int)` SQL 함수
  - `results.embedding <=>` 코사인 거리로 가장 가까운 공개 결과 반환
  - target 결과의 embedding이 null이면 빈 배열 반환 (JOIN 조건으로 자연 처리)
  - RLS 정책 자동 적용 (language sql stable, security invoker 기본값)

**`src/app/api/results/similar/route.ts`** (신설)
- `GET /api/results/similar?id={uuid}&limit={n}` (최대 20건)
- 400: `id` 없는 경우
- 500: DB 오류

> **선행 PR 의존성**
> - **PR #281** (pgvector 마이그레이션) — `embedding` 컬럼 및 `vector` extension 필요
> - **PR #282** (embedding 저장 job) — results에 실제 embedding 값이 채워져야 의미있는 결과 반환

## Test plan

- [ ] `GET /api/results/similar?id={실제_id}` → 유사 결과 배열 반환 확인
- [ ] 존재하지 않는 id 또는 embedding null인 id → `{ results: [] }` 확인
- [ ] `limit=20` 초과 파라미터 → 20건으로 clamp 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)