### PR TITLE
feat: closes #120 유사 스타일 사용자 조회 API — GET /api/users/similar

### DIFF
--- a/src/app/api/users/similar/route.ts
+++ b/src/app/api/users/similar/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get("user_id");
+  const limit = Math.min(Number(searchParams.get("limit") ?? "10"), 20);
+
+  if (!userId) {
+    return NextResponse.json({ error: "user_id가 필요합니다." }, { status: 400 });
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  const { data, error } = await supabase.rpc("match_users", {
+    target_user_id: userId,
+    match_count: limit,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ users: data ?? [] });
+}

--- a/supabase/migrations/0110_match_users_function.sql
+++ b/supabase/migrations/0110_match_users_function.sql
@@ -1,0 +1,39 @@
+-- #120
+-- 유사 스타일 사용자 조회 RPC 함수
+-- target 사용자의 최신 result embedding과 다른 사용자들의 평균 유사도로 순위 산정
+
+create or replace function public.match_users(
+  target_user_id uuid,
+  match_count int default 10
+)
+returns table (
+  profile_id uuid,
+  username text,
+  display_name text,
+  similarity float
+)
+language sql
+stable
+as $$
+  select
+    p.id as profile_id,
+    p.username,
+    p.display_name,
+    avg(1 - (r.embedding <=> t.embedding))::float as similarity
+  from results r
+  join profiles p on p.id = r.profile_id
+  cross join lateral (
+    select embedding
+    from results
+    where profile_id = target_user_id
+      and embedding is not null
+    order by created_at desc
+    limit 1
+  ) t
+  where r.embedding is not null
+    and r.is_public = true
+    and r.profile_id != target_user_id
+  group by p.id, p.username, p.display_name
+  order by similarity desc
+  limit match_count;
+$$;


### PR DESCRIPTION
## Summary

target 사용자의 최신 스타일 embedding과 코사인 유사도가 높은 다른 사용자를 찾는 API를 구현합니다.

**`supabase/migrations/0110_match_users_function.sql`** (신설)
- `match_users(target_user_id uuid, match_count int)` SQL 함수
  - target의 **가장 최근 result embedding** 기준으로 다른 사용자 공개 결과와 평균 유사도 산출
  - `profiles` 테이블 JOIN → username, display_name 함께 반환
  - `profile_id != target_user_id` + `is_public = true` 조건으로 본인 제외·공개 결과만 검색

**`src/app/api/users/similar/route.ts`** (신설)
- `GET /api/users/similar?user_id={uuid}&limit={n}` (최대 20건)
- 400: `user_id` 없는 경우
- target 사용자의 embedding이 없는 경우 → `{ users: [] }` 반환

> **선행 PR 의존성**
> - **PR #281** (pgvector 마이그레이션) — `vector` extension + `embedding` 컬럼 필요
> - **PR #282** (embedding 저장 job) — 실제 embedding 값 필요

## Test plan

- [ ] `GET /api/users/similar?user_id={실제_uuid}` → 유사 사용자 배열 반환 확인
- [ ] target에 embedding 없는 경우 → `{ users: [] }` 확인
- [ ] `limit=20` 초과 시 20건으로 clamp 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)