### PR TITLE
feat: closes #121 팔로우 API + FollowButton UI 컴포넌트

### DIFF
--- a/src/app/api/follows/route.ts
+++ b/src/app/api/follows/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function POST(req: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  let followingId: string | undefined;
+  try {
+    const body = await req.json();
+    followingId = body.following_id;
+  } catch {
+    return NextResponse.json({ error: "요청 형식이 올바르지 않습니다." }, { status: 400 });
+  }
+
+  if (!followingId) {
+    return NextResponse.json({ error: "following_id가 필요합니다." }, { status: 400 });
+  }
+
+  if (followingId === user.id) {
+    return NextResponse.json({ error: "자기 자신은 팔로우할 수 없습니다." }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from("follows")
+    .insert({ follower_id: user.id, following_id: followingId });
+
+  if (error) {
+    // 이미 팔로우 중 (unique violation) — 멱등 처리
+    if (error.code === "23505") return new NextResponse(null, { status: 204 });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return new NextResponse(null, { status: 204 });
+}
+
+export async function DELETE(req: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const followingId = new URL(req.url).searchParams.get("following_id");
+  if (!followingId) {
+    return NextResponse.json({ error: "following_id가 필요합니다." }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from("follows")
+    .delete()
+    .eq("follower_id", user.id)
+    .eq("following_id", followingId);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/follows/status/route.ts
+++ b/src/app/api/follows/status/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function GET(req: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ isFollowing: false });
+  }
+
+  const followingId = new URL(req.url).searchParams.get("following_id");
+  if (!followingId) {
+    return NextResponse.json({ error: "following_id가 필요합니다." }, { status: 400 });
+  }
+
+  const { data } = await supabase
+    .from("follows")
+    .select("follower_id")
+    .eq("follower_id", user.id)
+    .eq("following_id", followingId)
+    .maybeSingle();
+
+  return NextResponse.json({ isFollowing: data !== null });
+}

--- a/src/components/social/FollowButton.tsx
+++ b/src/components/social/FollowButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface IFollowButtonProps {
+  targetUserId: string;
+  initialIsFollowing?: boolean;
+}
+
+export function FollowButton({ targetUserId, initialIsFollowing }: IFollowButtonProps) {
+  const [isFollowing, setIsFollowing] = useState(initialIsFollowing ?? false);
+  const [isLoading, setIsLoading] = useState(initialIsFollowing === undefined);
+
+  useEffect(() => {
+    if (initialIsFollowing !== undefined) return;
+    fetch(`/api/follows/status?following_id=${targetUserId}`)
+      .then((res) => res.json())
+      .then((data) => setIsFollowing(data.isFollowing ?? false))
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  }, [targetUserId, initialIsFollowing]);
+
+  const handleClick = async () => {
+    setIsLoading(true);
+    const next = !isFollowing;
+
+    try {
+      if (next) {
+        await fetch("/api/follows", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ following_id: targetUserId }),
+        });
+      } else {
+        await fetch(`/api/follows?following_id=${targetUserId}`, { method: "DELETE" });
+      }
+      setIsFollowing(next);
+    } catch {
+      // 네트워크 오류 시 상태 복원 안 함 — 다음 렌더에서 서버 상태와 재동기화
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      variant={isFollowing ? "ghost" : "dark"}
+      size="sm"
+      disabled={isLoading}
+      onClick={handleClick}
+    >
+      {isLoading ? "..." : isFollowing ? "팔로잉" : "팔로우"}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

팔로우/언팔로우 REST API 3종과 팔로우 상태 토글 버튼 컴포넌트를 구현합니다.

**`POST /api/follows`**
- body: `{ following_id: string }`
- 본인 팔로우 시도 → 400
- 중복 팔로우 (unique violation) → 204 멱등 처리
- 성공 → 204 No Content

**`DELETE /api/follows?following_id=`**
- RLS `follows_delete_self` 정책으로 본인 팔로우만 삭제 가능
- 성공 → 204 No Content

**`GET /api/follows/status?following_id=`**
- 비로그인 → `{ isFollowing: false }`
- 로그인 → Supabase `follows` 테이블 조회 결과 반환

**`src/components/social/FollowButton.tsx`**
- `targetUserId`, `initialIsFollowing?` props
- `initialIsFollowing`이 없으면 마운트 시 `/api/follows/status` 호출로 상태 초기화
- 클릭 시 낙관적 토글 (POST/DELETE) + loading 비활성화

> `follows` 테이블과 RLS 정책은 `0001_initial_schema.sql`, `0107_supabase_rls_policies.sql`에 이미 정의되어 있어 **추가 마이그레이션 없음**.

## Test plan

- [ ] 로그인 상태에서 팔로우 버튼 클릭 → DB `follows` 테이블 row 생성 확인
- [ ] 팔로잉 상태에서 버튼 클릭 → row 삭제 확인
- [ ] 비로그인 상태에서 `GET /api/follows/status` → `{ isFollowing: false }` 확인
- [ ] 자기 자신 팔로우 → 400 오류 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)