### PR TITLE
feat: closes #124 재분석 API — POST /api/results/[id]/reanalyze

### DIFF
--- a/src/app/api/results/[id]/reanalyze/route.ts
+++ b/src/app/api/results/[id]/reanalyze/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { GrokApiError, GrokTimeoutError, callGrok } from "@/lib/grok";
+import { enrichResponseWithTmdb, enrichResponseWithUnsplash } from "@/lib/inference/enrichResponse";
+import { applyFallback } from "@/lib/inference/inference.fallback";
+import { normalizeInferenceResponse } from "@/lib/inference/inference.normalize";
+import { parseInferenceResponse } from "@/lib/inference/inference.parser";
+import { SYSTEM_PROMPT, buildUserPrompt } from "@/lib/inference/inference.prompts";
+import { safeParseRequest } from "@/lib/inference/inference.schema";
+import type { InferenceResult } from "@/lib/inference/inference.types";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+interface IRouteContext {
+  params: { id: string };
+}
+
+export async function POST(_req: NextRequest, { params }: IRouteContext) {
+  const supabase = await createSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from("results")
+    .select("request_payload, start_domain")
+    .eq("id", params.id)
+    .single();
+
+  if (error || !data?.request_payload) {
+    return NextResponse.json({ error: "원본 결과를 찾을 수 없습니다." }, { status: 404 });
+  }
+
+  const parsedReq = safeParseRequest(data.request_payload);
+  if (!parsedReq.success) {
+    return NextResponse.json({ error: "저장된 요청 데이터가 올바르지 않습니다." }, { status: 422 });
+  }
+
+  let raw: string;
+  try {
+    const userPrompt = buildUserPrompt(parsedReq.data);
+    raw = await callGrok([
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userPrompt },
+    ]);
+  } catch (e) {
+    if (e instanceof GrokTimeoutError) {
+      return NextResponse.json({ error: e.message }, { status: 504 });
+    }
+    if (e instanceof GrokApiError) {
+      return NextResponse.json({ error: e.message }, { status: 502 });
+    }
+    return NextResponse.json({ error: "추론 서비스 오류가 발생했습니다." }, { status: 500 });
+  }
+
+  const parsed = parseInferenceResponse(raw);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.message }, { status: 422 });
+  }
+
+  const normalized = normalizeInferenceResponse(parsed.data);
+  const fallbacked = applyFallback(normalized, parsedReq.data.domain);
+  const tmdbEnriched = await enrichResponseWithTmdb(fallbacked);
+  const enriched = await enrichResponseWithUnsplash(tmdbEnriched);
+
+  const result: InferenceResult = {
+    ...enriched,
+    id: crypto.randomUUID(),
+    createdAt: new Date().toISOString(),
+  };
+
+  return NextResponse.json({ result });
+}


### PR DESCRIPTION
## Summary

저장된 분석 결과의 `request_payload`를 재사용하여 새 분석 결과를 생성하는 API를 구현합니다.

**`POST /api/results/[id]/reanalyze`** (신설)

1. `results` 테이블에서 `id` 기준으로 `request_payload` + `start_domain` 조회
   - RLS 정책(`results_public_read`, `results_owner_read`) 자동 적용
   - 없으면 404
2. `safeParseRequest(request_payload)` 검증 — 형식 불일치 시 422
3. 기존 `/api/inference`와 동일한 파이프라인 실행
   - `callGrok` → `parseInferenceResponse` → `normalizeInferenceResponse` → `applyFallback` → enrich(TMDB, Unsplash)
4. 새 UUID + `createdAt`으로 **새 result** 반환 (`id`가 원본과 다름)

> 클라이언트는 응답받은 새 result를 `saveResult()`로 스토어에 저장 후 `/result/{newId}`로 이동하면 됩니다.
> 
> **선행 PR 의존성**: PR #278 머지 후 DB에 `request_payload`가 쌓여야 실제로 동작합니다.

## Test plan

- [ ] 존재하는 result id로 POST → 새 result (다른 id) 반환 확인
- [ ] 존재하지 않는 id → 404 확인
- [ ] 비로그인 상태에서 비공개 result 재분석 → 404 (RLS) 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)