### PR TITLE
feat: closes #126 결과 비교 UI — /compare?a=&b=

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import Image from "next/image";
+import { useSearchParams } from "next/navigation";
+
+import { ResultPageError } from "@/components/result/ResultPageError";
+import { useResultStore } from "@/store/resultStore";
+import type { StyleResult } from "@/types/result";
+
+function useCompareSide(id: string | null) {
+  const storedResult = useResultStore((s) => (id ? s.results[id] : undefined));
+  const saveResult = useResultStore((s) => s.saveResult);
+  const [fetched, setFetched] = useState<StyleResult | null>(null);
+  const [isFetching, setIsFetching] = useState(false);
+  const [fetchFailed, setFetchFailed] = useState(false);
+
+  useEffect(() => {
+    if (!id || storedResult || isFetching || fetchFailed) return;
+    setIsFetching(true);
+    fetch(`/api/results/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error();
+        return res.json();
+      })
+      .then((data) => {
+        saveResult(data.result);
+        setFetched(data.result);
+      })
+      .catch(() => setFetchFailed(true))
+      .finally(() => setIsFetching(false));
+  }, [id, storedResult, isFetching, fetchFailed, saveResult]);
+
+  return {
+    result: storedResult ?? fetched,
+    isFetching,
+    fetchFailed,
+  };
+}
+
+function CompareSide({
+  result,
+  isFetching,
+  fetchFailed,
+  label,
+}: {
+  result: StyleResult | null | undefined;
+  isFetching: boolean;
+  fetchFailed: boolean;
+  label: string;
+}) {
+  if (isFetching) {
+    return (
+      <div className="flex flex-1 items-center justify-center min-h-[40vh]">
+        <p className="type-body-lg text-on-surface-variant">{label} 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  if (fetchFailed || !result) {
+    return (
+      <div className="flex flex-1 items-center justify-center min-h-[40vh]">
+        <p className="type-body-md text-on-surface-variant">{label} 결과를 찾을 수 없어요.</p>
+      </div>
+    );
+  }
+
+  const { styleLabel, music, movie, fashion } = result;
+
+  return (
+    <div className="flex-1 min-w-0">
+      {/* Style Label Hero */}
+      <div className="rounded-[24px] p-6 mb-6" style={{ backgroundColor: styleLabel.themeColor }}>
+        <p className="font-headline font-black text-headline-md text-on-background uppercase mb-2">
+          {styleLabel.title}
+        </p>
+        <p className="font-korean text-body-md text-on-background/70 keep-all line-clamp-3">
+          {styleLabel.description}
+        </p>
+      </div>
+
+      {/* Music */}
+      <section className="mb-6">
+        <h3 className="font-headline font-black text-label-lg text-on-surface-variant uppercase mb-3">
+          Music
+        </h3>
+        <ul className="flex flex-col gap-2">
+          {music.slice(0, 3).map((track) => (
+            <li key={track.id} className="flex items-center gap-3">
+              {track.image && (
+                <Image
+                  src={track.image}
+                  alt={track.name}
+                  width={40}
+                  height={40}
+                  className="rounded-lg object-cover flex-shrink-0"
+                />
+              )}
+              <div className="min-w-0">
+                <p className="font-korean text-body-sm font-medium text-on-background truncate">
+                  {track.name}
+                </p>
+                <p className="font-korean text-body-xs text-on-surface-variant truncate">
+                  {track.artist}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Movie */}
+      <section className="mb-6">
+        <h3 className="font-headline font-black text-label-lg text-on-surface-variant uppercase mb-3">
+          Cinema
+        </h3>
+        <ul className="flex flex-col gap-2">
+          {movie.slice(0, 3).map((m) => (
+            <li key={m.id} className="font-korean text-body-sm text-on-background">
+              {m.title}
+              <span className="text-on-surface-variant ml-2 text-body-xs">
+                {m.genres.slice(0, 2).join(" · ")}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Fashion */}
+      <section>
+        <h3 className="font-headline font-black text-label-lg text-on-surface-variant uppercase mb-3">
+          Fashion
+        </h3>
+        <ul className="flex flex-col gap-2">
+          {fashion.slice(0, 3).map((item, i) => (
+            <li key={i} className="font-korean text-body-sm text-on-background">
+              {item.keyword}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+export default function ComparePage() {
+  const searchParams = useSearchParams();
+  const idA = searchParams.get("a");
+  const idB = searchParams.get("b");
+
+  const sideA = useCompareSide(idA);
+  const sideB = useCompareSide(idB);
+
+  if (!idA || !idB) {
+    return (
+      <ResultPageError message="비교할 결과 ID가 없어요. URL에 ?a=...&b=... 형식으로 입력해주세요." />
+    );
+  }
+
+  return (
+    <div className="page-container section-wrapper">
+      <header className="mb-8">
+        <h1 className="type-headline-lg keep-all">
+          스타일 <span className="text-primary-container">비교</span>
+        </h1>
+        <p className="type-body-lg text-on-surface-variant mt-2">
+          두 분석 결과를 나란히 확인해보세요.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-8 lg:flex-row lg:gap-10">
+        <CompareSide {...sideA} label="결과 A" />
+        <div className="w-px bg-outline-variant hidden lg:block flex-shrink-0" aria-hidden="true" />
+        <CompareSide {...sideB} label="결과 B" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

두 분석 결과를 나란히 비교할 수 있는 `/compare?a={id}&b={id}` 페이지를 구현합니다.

**`src/app/compare/page.tsx`** (신설)

- `useSearchParams()`로 `a`, `b` UUID 파라미터 수신
- 각 side마다 `useCompareSide(id)` 훅: `useResultStore` → miss 시 `/api/results/{id}` fallback
- 로딩/실패 상태 per-side 독립 처리 (한 쪽 로드 실패해도 나머지 표시)
- 레이아웃: 모바일 세로 스택 → PC 좌우 2컬럼 (`lg:flex-row`)
- 각 side: themeColor 배경 스타일 레이블 + Music / Cinema / Fashion 상위 3개씩 표시
- `a` 또는 `b` 파라미터 없는 경우 → `ResultPageError` 안내 메시지

> **선행 PR 의존성**: PR #280 (`GET /api/results/[id]`)이 머지되어야 DB fallback이 작동합니다. 스토어에 결과가 있는 경우는 선행 PR 없이도 동작합니다.

## Test plan

- [ ] `/compare?a={id1}&b={id2}` 접속 → 두 결과 좌우 비교 확인
- [ ] 한 쪽 ID가 없는 경우 → 에러 메시지 표시 확인
- [ ] PC 화면에서 좌우 2컬럼 레이아웃 확인
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)