### PR TITLE
feat: closes #116 #117 피드 목록 API + 타임라인 UI

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -32,7 +32,10 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ items: [], nextCursor: null });
   }
 
-  // 팔로잉 사용자들의 공개 결과 최신순 조회
+  // 팔로잉 사용자들의 공개 결과 최신순 조회.
+  // 작성자가 프로필을 'private'으로 설정한 경우 팔로워 피드에서도 제외한다.
+  // ('public'/'followers'는 뷰어가 팔로워이므로 노출 정상 — 피드 자체가 팔로잉 대상.)
+  // profiles!inner + 임베드 컬럼 필터라 부모(results) 행까지 함께 걸러진다.
   let query = supabase
     .from("results")
     .select(
@@ -43,12 +46,14 @@ export async function GET(req: NextRequest) {
       created_at,
       profiles!inner (
         username,
-        display_name
+        display_name,
+        visibility
       )
     `
     )
     .eq("is_public", true)
     .in("profile_id", followingIds)
+    .neq("profiles.visibility", "private")
     .order("created_at", { ascending: false })
     .limit(limit);
 

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 30;
+
+export async function GET(req: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: "로그인이 필요합니다." }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const cursor = searchParams.get("cursor"); // ISO timestamp
+  const limit = Math.min(Number(searchParams.get("limit") ?? DEFAULT_LIMIT), MAX_LIMIT);
+
+  // 팔로잉 목록 조회
+  const { data: followingData } = await supabase
+    .from("follows")
+    .select("following_id")
+    .eq("follower_id", user.id);
+
+  const followingIds = (followingData ?? []).map((f: { following_id: string }) => f.following_id);
+
+  if (followingIds.length === 0) {
+    return NextResponse.json({ items: [], nextCursor: null });
+  }
+
+  // 팔로잉 사용자들의 공개 결과 최신순 조회
+  let query = supabase
+    .from("results")
+    .select(
+      `
+      id,
+      style_label,
+      start_domain,
+      created_at,
+      profiles!inner (
+        username,
+        display_name
+      )
+    `
+    )
+    .eq("is_public", true)
+    .in("profile_id", followingIds)
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (cursor) {
+    query = query.lt("created_at", cursor);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const items = data ?? [];
+  const nextCursor = items.length === limit ? items[items.length - 1].created_at : null;
+
+  return NextResponse.json({ items, nextCursor });
+}

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { FeedCard } from "@/components/social/FeedCard";
+import type { StyleLabel } from "@/types/result";
+
+interface FeedItem {
+  id: string;
+  style_label: StyleLabel;
+  start_domain: string;
+  created_at: string;
+  profiles: {
+    username: string;
+    display_name: string | null;
+  };
+}
+
+export default function FeedPage() {
+  const [items, setItems] = useState<FeedItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const fetchFeed = useCallback(async (cursor?: string) => {
+    const params = new URLSearchParams({ limit: "10" });
+    if (cursor) params.set("cursor", cursor);
+
+    const res = await fetch(`/api/feed?${params}`);
+    if (!res.ok) {
+      if (res.status === 401) throw new Error("LOGIN_REQUIRED");
+      throw new Error("피드를 불러오는 데 실패했습니다.");
+    }
+    return res.json() as Promise<{ items: FeedItem[]; nextCursor: string | null }>;
+  }, []);
+
+  useEffect(() => {
+    fetchFeed()
+      .then(({ items: newItems, nextCursor: nc }) => {
+        setItems(newItems);
+        setNextCursor(nc);
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setIsLoading(false));
+  }, [fetchFeed]);
+
+  // 무한 스크롤 — sentinel IntersectionObserver
+  useEffect(() => {
+    if (!sentinelRef.current || !nextCursor) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0]?.isIntersecting || isLoadingMore || !nextCursor) return;
+        setIsLoadingMore(true);
+        fetchFeed(nextCursor)
+          .then(({ items: newItems, nextCursor: nc }) => {
+            setItems((prev) => [...prev, ...newItems]);
+            setNextCursor(nc);
+          })
+          .catch(() => {})
+          .finally(() => setIsLoadingMore(false));
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(sentinelRef.current);
+    return () => observer.disconnect();
+  }, [nextCursor, isLoadingMore, fetchFeed]);
+
+  if (isLoading) {
+    return (
+      <div className="page-container section-wrapper flex items-center justify-center min-h-[50vh]">
+        <p className="type-body-lg text-on-surface-variant">피드를 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  if (error === "LOGIN_REQUIRED") {
+    return (
+      <div className="page-container section-wrapper flex flex-col items-center justify-center min-h-[50vh] gap-4 text-center">
+        <p className="type-body-lg text-on-surface-variant">피드를 보려면 로그인이 필요해요.</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="page-container section-wrapper flex items-center justify-center min-h-[50vh]">
+        <p className="type-body-lg text-on-surface-variant">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page-container section-wrapper">
+      <header className="mb-8">
+        <h1 className="type-headline-lg keep-all">
+          피드 <span className="text-primary-container">타임라인</span>
+        </h1>
+        <p className="type-body-lg text-on-surface-variant mt-2">
+          팔로우한 사람들의 최신 스타일을 확인하세요.
+        </p>
+      </header>
+
+      {items.length === 0 ? (
+        <div className="flex flex-col items-center justify-center min-h-[30vh] gap-3 text-center">
+          <p className="type-body-lg text-on-surface-variant keep-all">
+            아직 팔로우한 사람이 없거나 최신 결과가 없어요.
+          </p>
+          <p className="type-body-md text-on-surface-variant">
+            유사한 취향의 사람들을 팔로우해 보세요.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {items.map((item) => (
+              <FeedCard
+                key={item.id}
+                id={item.id}
+                styleLabel={item.style_label}
+                startDomain={item.start_domain}
+                createdAt={item.created_at}
+                username={item.profiles.username}
+                displayName={item.profiles.display_name}
+              />
+            ))}
+          </div>
+
+          {/* Infinite scroll sentinel */}
+          <div ref={sentinelRef} className="h-10 mt-6" />
+          {isLoadingMore && (
+            <p className="text-center type-body-md text-on-surface-variant pb-4">
+              더 불러오는 중...
+            </p>
+          )}
+          {!nextCursor && items.length > 0 && (
+            <p className="text-center type-body-md text-on-surface-variant pb-4">
+              모두 확인했어요.
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/social/FeedCard.tsx
+++ b/src/components/social/FeedCard.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+
+import type { StyleLabel } from "@/types/result";
+
+interface IFeedCardProps {
+  id: string;
+  styleLabel: StyleLabel;
+  startDomain: string;
+  createdAt: string;
+  username: string;
+  displayName: string | null;
+}
+
+const DOMAIN_LABEL: Record<string, string> = {
+  music: "MUSIC",
+  movie: "MOVIE",
+  fashion: "FASHION",
+};
+
+export function FeedCard({
+  id,
+  styleLabel,
+  startDomain,
+  createdAt,
+  username,
+  displayName,
+}: IFeedCardProps) {
+  const date = new Date(createdAt).toLocaleDateString("ko-KR", {
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <Link href={`/result/${id}`} className="block group">
+      <article className="rounded-[24px] overflow-hidden border border-outline-variant hover:border-outline transition-colors">
+        {/* 스타일 레이블 헤더 */}
+        <div className="px-5 py-4" style={{ backgroundColor: styleLabel.themeColor }}>
+          <p className="font-headline font-black text-body-lg text-on-background uppercase">
+            {styleLabel.title}
+          </p>
+          <p className="font-korean text-body-sm text-on-background/70 keep-all line-clamp-2 mt-1">
+            {styleLabel.description}
+          </p>
+        </div>
+
+        {/* 메타 */}
+        <div className="flex items-center justify-between px-5 py-3 bg-surface">
+          <div className="flex items-center gap-2">
+            <div className="w-7 h-7 rounded-full bg-primary-container flex items-center justify-center flex-shrink-0">
+              <span className="font-headline font-black text-label-sm text-on-primary-container uppercase">
+                {(displayName ?? username).charAt(0)}
+              </span>
+            </div>
+            <div>
+              <p className="font-korean text-body-sm font-medium text-on-background leading-none">
+                {displayName ?? username}
+              </p>
+              <p className="font-korean text-body-xs text-on-surface-variant leading-none mt-0.5">
+                @{username}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <span className="font-headline text-label-xs text-on-surface-variant uppercase">
+              {DOMAIN_LABEL[startDomain] ?? startDomain}
+            </span>
+            <span className="font-korean text-body-xs text-on-surface-variant">{date}</span>
+          </div>
+        </div>
+      </article>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

팔로우한 사용자들의 최신 스타일 결과를 보여주는 피드를 구현합니다.

**`GET /api/feed?cursor=&limit=`** (신설)
- 인증 필수 (401)
- `follows` 테이블에서 팔로잉 목록 조회 → 해당 사용자들의 공개 `results` 최신순 반환
- cursor-based 페이지네이션 (`created_at` 기준 `lt`)
- 팔로잉이 없는 경우 즉시 `{ items: [], nextCursor: null }` 반환

**`FeedCard`** (신설) — themeColor 배경 스타일 레이블 + 프로필 이니셜 아바타

**`/feed`** (신설) — IntersectionObserver 무한 스크롤, 로딩/빈 상태/에러 처리

> 선행 PR: #285 (팔로우 API) 머지 후 실제 팔로잉 데이터 필요

## Test plan

- [ ] 팔로우 사용자 있는 계정 → /feed 카드 목록 표시
- [ ] 스크롤 다운 시 다음 페이지 자동 로드
- [ ] 팔로우 없는 계정 → 빈 상태 메시지
- [ ] 비로그인 → 로그인 안내
- [ ] `pnpm type-check` / `pnpm lint` 통과 ✅

closes #116
closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)