### PR TITLE
feat: closes #112 유사 스타일 사용자 탐색 페이지 — /explore

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -68,7 +68,7 @@ export default function ExplorePage() {
       {isAuthenticated && !isLoading && !error && users.length === 0 && (
         <div className="flex flex-col items-center justify-center min-h-[40vh] gap-3 text-center">
           <p className="type-body-lg text-on-surface-variant keep-all">
-            아직 비교할 스타일 데이터가 없어요.
+            아직 탐색할 유사 스타일 사용자가 없어요.
           </p>
           <p className="type-body-md text-on-surface-variant">먼저 스타일 분석을 완료해 보세요.</p>
         </div>

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { UserCard } from "@/components/social/UserCard";
+import { useAuthSessionStore } from "@/store/authSessionStore";
+
+interface SimilarUser {
+  profile_id: string;
+  username: string;
+  display_name: string | null;
+  similarity: number;
+}
+
+export default function ExplorePage() {
+  const isAuthenticated = useAuthSessionStore((s) => s.isAuthenticated);
+  const userId = useAuthSessionStore((s) => s.user?.id);
+
+  const [users, setUsers] = useState<SimilarUser[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated || !userId) return;
+
+    setIsLoading(true);
+    fetch(`/api/users/similar?user_id=${userId}&limit=20`)
+      .then((res) => {
+        if (!res.ok) throw new Error("유사 사용자를 불러오는 데 실패했습니다.");
+        return res.json();
+      })
+      .then((data) => setUsers(data.users ?? []))
+      .catch((e) => setError(e.message))
+      .finally(() => setIsLoading(false));
+  }, [isAuthenticated, userId]);
+
+  return (
+    <div className="page-container section-wrapper">
+      <header className="mb-8">
+        <h1 className="type-headline-lg keep-all">
+          스타일 <span className="text-primary-container">탐색</span>
+        </h1>
+        <p className="type-body-lg text-on-surface-variant mt-2">
+          당신과 비슷한 취향을 가진 사람들을 만나보세요.
+        </p>
+      </header>
+
+      {!isAuthenticated && (
+        <div className="flex flex-col items-center justify-center min-h-[40vh] gap-3 text-center">
+          <p className="type-body-lg text-on-surface-variant keep-all">
+            유사한 스타일의 사용자를 찾으려면 로그인이 필요해요.
+          </p>
+        </div>
+      )}
+
+      {isAuthenticated && isLoading && (
+        <div className="flex items-center justify-center min-h-[40vh]">
+          <p className="type-body-lg text-on-surface-variant">유사 사용자를 분석 중...</p>
+        </div>
+      )}
+
+      {isAuthenticated && !isLoading && error && (
+        <div className="flex items-center justify-center min-h-[40vh]">
+          <p className="type-body-lg text-on-surface-variant">{error}</p>
+        </div>
+      )}
+
+      {isAuthenticated && !isLoading && !error && users.length === 0 && (
+        <div className="flex flex-col items-center justify-center min-h-[40vh] gap-3 text-center">
+          <p className="type-body-lg text-on-surface-variant keep-all">
+            아직 비교할 스타일 데이터가 없어요.
+          </p>
+          <p className="type-body-md text-on-surface-variant">먼저 스타일 분석을 완료해 보세요.</p>
+        </div>
+      )}
+
+      {isAuthenticated && !isLoading && users.length > 0 && (
+        <div className="flex flex-col gap-3 max-w-2xl">
+          {users.map((user) => (
+            <UserCard
+              key={user.profile_id}
+              profileId={user.profile_id}
+              username={user.username}
+              displayName={user.display_name}
+              similarity={user.similarity}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/social/FollowButton.tsx
+++ b/src/components/social/FollowButton.tsx
@@ -38,7 +38,7 @@ export function FollowButton({ targetUserId, initialIsFollowing }: IFollowButton
       }
       setIsFollowing(next);
     } catch {
-      // 네트워크 오류 시 다음 렌더에서 서버 상태와 재동기화
+      // 네트워크 오류 시 상태 복원 안 함 — 다음 렌더에서 서버 상태와 재동기화
     } finally {
       setIsLoading(false);
     }

--- a/src/components/social/FollowButton.tsx
+++ b/src/components/social/FollowButton.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface IFollowButtonProps {
+  targetUserId: string;
+  initialIsFollowing?: boolean;
+}
+
+export function FollowButton({ targetUserId, initialIsFollowing }: IFollowButtonProps) {
+  const [isFollowing, setIsFollowing] = useState(initialIsFollowing ?? false);
+  const [isLoading, setIsLoading] = useState(initialIsFollowing === undefined);
+
+  useEffect(() => {
+    if (initialIsFollowing !== undefined) return;
+    fetch(`/api/follows/status?following_id=${targetUserId}`)
+      .then((res) => res.json())
+      .then((data) => setIsFollowing(data.isFollowing ?? false))
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  }, [targetUserId, initialIsFollowing]);
+
+  const handleClick = async () => {
+    setIsLoading(true);
+    const next = !isFollowing;
+
+    try {
+      if (next) {
+        await fetch("/api/follows", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ following_id: targetUserId }),
+        });
+      } else {
+        await fetch(`/api/follows?following_id=${targetUserId}`, { method: "DELETE" });
+      }
+      setIsFollowing(next);
+    } catch {
+      // 네트워크 오류 시 다음 렌더에서 서버 상태와 재동기화
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      variant={isFollowing ? "ghost" : "dark"}
+      size="sm"
+      disabled={isLoading}
+      onClick={handleClick}
+    >
+      {isLoading ? "..." : isFollowing ? "팔로잉" : "팔로우"}
+    </Button>
+  );
+}

--- a/src/components/social/UserCard.tsx
+++ b/src/components/social/UserCard.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+import { FollowButton } from "@/components/social/FollowButton";
+
+interface IUserCardProps {
+  profileId: string;
+  username: string;
+  displayName: string | null;
+  similarity?: number;
+}
+
+export function UserCard({ profileId, username, displayName, similarity }: IUserCardProps) {
+  return (
+    <article className="flex items-center justify-between gap-4 rounded-[16px] border border-outline-variant px-5 py-4 bg-surface">
+      <Link href={`/profile/${username}`} className="flex items-center gap-3 min-w-0 flex-1">
+        <div className="w-10 h-10 rounded-full bg-primary-container flex items-center justify-center flex-shrink-0">
+          <span className="font-headline font-black text-label-md text-on-primary-container uppercase">
+            {(displayName ?? username).charAt(0)}
+          </span>
+        </div>
+        <div className="min-w-0">
+          <p className="font-korean text-body-md font-medium text-on-background truncate">
+            {displayName ?? username}
+          </p>
+          <p className="font-korean text-body-xs text-on-surface-variant truncate">@{username}</p>
+          {similarity !== undefined && (
+            <p className="font-korean text-body-xs text-primary mt-0.5">
+              유사도 {Math.round(similarity * 100)}%
+            </p>
+          )}
+        </div>
+      </Link>
+      <div className="flex-shrink-0">
+        <FollowButton targetUserId={profileId} />
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary

embedding 기반 유사 스타일 사용자를 탐색하고 팔로우할 수 있는 /explore 페이지를 구현합니다.

**`src/components/social/FollowButton.tsx`** (포함)
- 팔로우 상태 토글 클라이언트 컴포넌트
- `initialIsFollowing` 없으면 마운트 시 `GET /api/follows/status` 초기화

**`src/components/social/UserCard.tsx`** (신설)
- 프로필 이니셜 아바타 + display_name + @username + 유사도 %
- `FollowButton` 포함, 카드 클릭 → `/profile/{username}`

**`src/app/explore/page.tsx`** (신설)
- `useAuthSessionStore`에서 `userId` 추출 → `GET /api/users/similar?user_id=` 호출
- 비로그인 / 로딩 / 데이터없음 / 에러 상태 처리

> **선행 PR 의존성**
> - PR #281 + #282 (embedding 저장) — 실제 유사도 계산을 위한 embedding 필요
> - PR #284 (`GET /api/users/similar`) — 이 PR에서 호출하는 API

closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)