### PR TITLE
style: TasteInputForm 하드코딩 색상 → 디자인 시스템 토큰 교체

### DIFF
--- a/src/components/domain/tasteInputForm/TasteInputForm.tsx
+++ b/src/components/domain/tasteInputForm/TasteInputForm.tsx
@@ -34,10 +34,10 @@ export function TasteInputForm({
         <div className="flex flex-col gap-4">
           <h1 className="type-headline-lg">
             {title}
-            <span className="text-orange-500"> 선택</span>
+            <span className="text-primary-container"> 선택</span>
           </h1>
 
-          <p className="type-body-lg text-stone-600">{description}</p>
+          <p className="type-body-lg text-on-surface-variant">{description}</p>
         </div>
 
         <StepIndicator current={2} total={2} />
@@ -57,7 +57,7 @@ export function TasteInputForm({
       */}
       {/* 검색바 */}
       <div className="relative mb-8 w-full">
-        <div className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-stone-400">
+        <div className="pointer-events-none absolute left-5 top-1/2 -translate-y-1/2 text-on-surface-variant/60">
           <Icon name="search" size={20} />
         </div>
 
@@ -66,7 +66,7 @@ export function TasteInputForm({
           value={searchQuery}
           onChange={(event) => onSearchChange(event.target.value)}
           placeholder={searchPlaceholder}
-          className="w-full rounded-full bg-white py-3 pl-12 pr-5 text-sm shadow-sm placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-500/30"
+          className="w-full rounded-full bg-white py-3 pl-12 pr-5 text-sm shadow-sm placeholder:text-on-surface-variant/60 focus:outline-none focus:ring-2 focus:ring-primary-container/30"
         />
       </div>
 
@@ -82,7 +82,7 @@ export function TasteInputForm({
         </p>
       )}
 
-      {errorMessage && <p className="mb-4 text-center text-sm text-red-400">{errorMessage}</p>}
+      {errorMessage && <p className="mb-4 text-center text-sm text-error">{errorMessage}</p>}
 
       <BottomNav
         prevPath={`/taste/${domain}`}


### PR DESCRIPTION
## 반영 브랜치
SS-243-TasteInputFormTokens → dev

## PR 타입
- [x] 스타일 수정

## 배경

`TasteInputForm.tsx` 및 `taste/[domain]/detail/page.tsx`에 Tailwind 하드코딩 색상이 사용되고 있어 디자인 시스템 토큰으로 교체합니다. 이슈 #243(피그마 확정 대기)의 `selectionMsg` 부분은 이 PR에서 건드리지 않습니다.

## 변경 내용

| 파일 | 교체 전 | 교체 후 |
|------|---------|---------|
| TasteInputForm.tsx | `text-orange-500` | `text-primary-container` |
| TasteInputForm.tsx | `text-stone-600` | `text-on-surface-variant` |
| TasteInputForm.tsx | `text-stone-400` / `placeholder:text-stone-400` | `text-on-surface-variant/60` |
| TasteInputForm.tsx | `focus:ring-orange-500/30` | `focus:ring-primary-container/30` |
| TasteInputForm.tsx | `text-red-400` | `text-error` |
| detail/page.tsx | `text-stone-400` (검색 상태 메시지 3곳) | `text-on-surface-variant/60` |
| detail/page.tsx | `text-red-400` (에러) | `text-error` |

## 주의

`taste/[domain]/detail/page.tsx`가 PR #251(seungyeonleeee)과 겹칩니다. PR #251 rebase 완료 후 이 PR을 먼저 merge하거나, 충돌 해결 시 이 변경을 포함해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)