### PR TITLE
fix / SS-296-AudioPlayResumeCatch - 오디오 재개 경로 play() Promise 미처리 수정

### DIFF
--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -32,6 +32,20 @@ export function useAudioPlayer(): IUseAudioPlayerReturn {
     setPlayingUrl(null);
   }, []);
 
+  // play()는 Promise를 반환하며 iOS Safari 자동재생 정책(NotAllowedError) 등으로
+  // 거절될 수 있다. 실패 시 재생 상태를 롤백해 UI가 실제 상태와 어긋나지 않게 한다.
+  // 신규 재생·재개 두 경로가 공유한다. (#296)
+  const playSafely = useCallback((audio: HTMLAudioElement, url: string) => {
+    setPlayingUrl(url);
+    setIsPlaying(true);
+    audio.play().catch(() => {
+      // 재생 시작 실패 — 그 사이 다른 트랙으로 교체됐다면 최신 상태를 건드리지 않는다
+      if (audioRef.current !== audio) return;
+      setIsPlaying(false);
+      setPlayingUrl(null);
+    });
+  }, []);
+
   const toggle = useCallback(
     (url: string) => {
       // 동일 URL — 재생/일시정지 토글
@@ -39,9 +53,8 @@ export function useAudioPlayer(): IUseAudioPlayerReturn {
         if (isPlaying) {
           audioRef.current?.pause();
           setIsPlaying(false);
-        } else {
-          audioRef.current?.play();
-          setIsPlaying(true);
+        } else if (audioRef.current) {
+          playSafely(audioRef.current, url);
         }
         return;
       }
@@ -52,14 +65,9 @@ export function useAudioPlayer(): IUseAudioPlayerReturn {
       const audio = new Audio(url);
       audio.addEventListener("ended", handleEnded);
       audioRef.current = audio;
-      audio.play().catch(() => {
-        setIsPlaying(false);
-        setPlayingUrl(null);
-      });
-      setPlayingUrl(url);
-      setIsPlaying(true);
+      playSafely(audio, url);
     },
-    [playingUrl, isPlaying, stop, handleEnded]
+    [playingUrl, isPlaying, stop, handleEnded, playSafely]
   );
 
   // 언마운트 시 재생 중단


### PR DESCRIPTION
## PR 본문

### 반영 브랜치

SS-296-AudioPlayResumeCatch -> dev

closes #296

### PR 타입

- [x] 버그 수정

### 작업 내용

`useAudioPlayer`의 `toggle()`은 **신규 재생**과 **재개(일시정지 후 다시 재생)** 두 경로로 갈리는데, 신규 재생 경로에만 `play()` 실패 처리가 있고 재개 경로에는 없었습니다. `HTMLMediaElement.play()`는 Promise를 반환하며 iOS Safari 자동재생 정책(`NotAllowedError`) 등으로 거절될 수 있어, 재개 실패 시 `isPlaying`이 `true`로 남아 UI(재생 오버레이·이퀄라이저)가 실제 상태와 어긋났습니다.

#### 변경점

1. **두 경로의 `play()` + 롤백 로직을 `playSafely` 헬퍼로 통합** — 중복 제거
2. **재개 경로에도 `.catch()` 적용** — 거절 시 재생 상태 롤백 (이 이슈의 핵심)
3. **롤백 전 `audioRef` 비교 가드 추가** — 아래 부수 버그도 함께 해소

```ts
const playSafely = useCallback((audio: HTMLAudioElement, url: string) => {
  setPlayingUrl(url);
  setIsPlaying(true);
  audio.play().catch(() => {
    // 그 사이 다른 트랙으로 교체됐다면 최신 상태를 건드리지 않는다
    if (audioRef.current !== audio) return;
    setIsPlaying(false);
    setPlayingUrl(null);
  });
}, []);
```

#### 함께 고친 부수 버그 (같은 성격)

- **트랙 전환 시 오작동**: 기존 신규 재생 경로의 `.catch()`는 stale 가드가 없어서, A 재생 중 B로 전환하면 pause로 인해 거절된 **A의 `AbortError`가 B의 재생 상태를 꺼버리는** 문제가 있었습니다. `audioRef` 비교 가드로 해소.
- **audioRef null일 때**: 기존 재개 경로는 `audioRef.current?.play()`가 no-op이어도 `setIsPlaying(true)`를 실행해 "오디오 없는데 재생 중" 상태가 될 수 있었습니다. `else if (audioRef.current)` 가드로 해소.

### 테스트 결과

- `npx tsc --noEmit` 통과
- `npx eslint src/hooks/useAudioPlayer.ts --max-warnings=0` 통과
- ⚠️ **자동 테스트 미포함**: 이 훅은 브라우저 `Audio` API + iOS 자동재생 정책에 의존해, 검증하려면 `@testing-library/react` + jsdom + `Audio` 목킹이 필요합니다. 현재 저장소 vitest 구성(node 순수 함수 / Storybook 브라우저)에 없는 인프라라, 작은 수정 하나를 위해 공유 테스트 설정을 새로 들이는 건 과하다고 판단해 정적 검증 + 로직 추적으로 대체했습니다. 실동작 검증은 브라우저 호환성 문서(#93 / PR #297) 4장 QA 체크리스트 A·B(iOS Safari / Android Chrome 미리듣기 재생) 항목에서 커버됩니다.

### 리뷰 요구사항

- 이 이슈는 브라우저 호환성 조사(#93) 중 발견해 등록한 건입니다. 배경은 `docs/browser-compatibility.md` 3.3절 참고 (PR #297).
- `useAudioPlayer.ts`는 현재 열려 있는 다른 PR 어디에도 포함되지 않아 충돌 없이 머지 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKLhaEPP1Lh7CdfhcFsNY7