### PR TITLE
chore / SS-301-IsPublicDefaultFalse - results.is_public 스키마 기본값 false

### DIFF
--- a/supabase/migrations/0112_results_is_public_default_false.sql
+++ b/supabase/migrations/0112_results_is_public_default_false.sql
@@ -1,0 +1,12 @@
+-- #301
+-- results.is_public 스키마 기본값을 true → false 로 변경 (기본 비공개)
+--
+-- 배경: 앱 레벨에서는 #278에서 POST /api/results insert 시 is_public:false를 명시했지만,
+-- 스키마 기본값(0103)이 여전히 true라, is_public을 명시하지 않는 insert 경로가
+-- 새로 생기면 결과가 공개로 저장되는 잠재 리스크가 남는다.
+-- "명시 안 하면 비공개"가 안전 기본값이므로 스키마 기본값 자체를 false로 내린다.
+--
+-- 주의: 기존 행의 is_public 값은 건드리지 않는다 (default 변경은 신규 insert에만 영향).
+
+alter table public.results
+  alter column is_public set default false;


### PR DESCRIPTION
## PR 본문

### 반영 브랜치

SS-301-IsPublicDefaultFalse -> dev

closes #301

### PR 타입

- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (DB 마이그레이션)

### 작업 내용

`results.is_public`의 스키마 기본값을 `true` → `false`로 변경합니다.

```sql
alter table public.results
  alter column is_public set default false;
```

- 앱 레벨에서는 #278에서 이미 insert 시 `is_public: false`를 명시했지만, 스키마 기본값(`0103`)이 여전히 `true`라 `is_public`을 명시하지 않는 insert 경로가 새로 생기면 공개로 저장되는 잠재 리스크가 있었습니다.
- "명시 안 하면 비공개"가 안전 기본값이므로 스키마 기본값 자체를 내렸습니다.
- **기존 행의 `is_public` 값은 건드리지 않습니다** — default 변경은 신규 insert에만 영향.

### 마이그레이션 번호

`0112`로 지정했습니다. `0111`은 #287(RLS 정책 검증)이 점유 예정이라 충돌을 피했습니다.

### 테스트 결과

- SQL 전용 변경 (tsc/lint 대상 없음)
- 로컬 DB 미보유로 실행 검증은 못 했으나, `0103`의 기존 `alter column ... set default` 패턴을 그대로 따릅니다.

### 리뷰 요구사항

- 접근 제어 3종(#278 앱 명시 / #280 GET 소유자 체크 / #287 RLS)과 함께 보는 방어 계층입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKLhaEPP1Lh7CdfhcFsNY7