### PR TITLE
feat / SS-299-RpcVisibilityFilter - 유사도 검색 RPC에 followers visibility 반영

### DIFF
--- a/supabase/migrations/0113_rpc_visibility_filter.sql
+++ b/supabase/migrations/0113_rpc_visibility_filter.sql
@@ -1,0 +1,117 @@
+-- #299
+-- 유사도 검색 RPC(match_results / match_users)에 작성자 profiles.visibility 반영
+--
+-- 배경: 두 함수는 results.is_public = true 만 필터해서, 프로필을 'followers'로 설정한
+-- 사용자의 결과가 팔로워가 아닌 호출자에게도 유사검색에 노출될 수 있었다.
+-- (피드 #289 / 프로필 #279는 이미 visibility를 반영. RPC만 남아 있었음 — #290 후속)
+--
+-- 정책: is_public = true 이고 && 작성자 프로필이 호출자에게 열람 가능할 때만 반환.
+--   public    → 전체 노출
+--   followers → 호출자가 팔로워일 때만 (auth.uid() 기준)
+--   private   → 제외 (이미 #290 kill-switch로 is_public=false가 되지만 방어적으로도 제외됨)
+--
+-- 두 함수 모두 language sql / SECURITY INVOKER 이므로 PostgREST RPC 호출 시 auth.uid()가
+-- 호출자를 가리킨다. anon 호출(match_results)에서는 auth.uid()가 null → followers 분기 false
+-- → public 결과만 노출된다.
+
+create or replace function public.match_results(
+  target_id uuid,
+  match_count int default 10
+)
+returns table (
+  id uuid,
+  style_label jsonb,
+  start_domain text,
+  created_at timestamptz,
+  similarity float
+)
+language sql
+stable
+as $$
+  select
+    r.id,
+    r.style_label,
+    r.start_domain,
+    r.created_at,
+    1 - (r.embedding <=> t.embedding) as similarity
+  from results r
+  join profiles p on p.id = r.profile_id
+  join (
+    select embedding
+    from results
+    where id = target_id
+      and embedding is not null
+  ) t on true
+  where r.embedding is not null
+    and r.is_public = true
+    and r.id != target_id
+    and (
+      p.visibility = 'public'
+      or (
+        p.visibility = 'followers'
+        and exists (
+          select 1
+          from follows f
+          where f.following_id = p.id
+            and f.follower_id = auth.uid()
+        )
+      )
+    )
+  order by r.embedding <=> t.embedding
+  limit match_count;
+$$;
+
+create or replace function public.match_users(
+  target_user_id uuid,
+  match_count int default 10
+)
+returns table (
+  profile_id uuid,
+  username text,
+  display_name text,
+  similarity float
+)
+language sql
+stable
+as $$
+  select
+    p.id as profile_id,
+    p.username,
+    p.display_name,
+    avg(1 - (r.embedding <=> t.embedding))::float as similarity
+  from results r
+  join profiles p on p.id = r.profile_id
+  cross join lateral (
+    select embedding
+    from results
+    where profile_id = target_user_id
+      and embedding is not null
+    order by created_at desc
+    limit 1
+  ) t
+  where r.embedding is not null
+    and r.is_public = true
+    and r.profile_id != target_user_id
+    and (
+      p.visibility = 'public'
+      or (
+        p.visibility = 'followers'
+        and exists (
+          select 1
+          from follows f
+          where f.following_id = p.id
+            and f.follower_id = auth.uid()
+        )
+      )
+    )
+  group by p.id, p.username, p.display_name
+  order by similarity desc
+  limit match_count;
+$$;
+
+-- EXECUTE 권한 재확인 (0111과 동일 — create or replace가 ACL을 보존하지만 방어적으로 명시)
+revoke all on function public.match_results(uuid, int) from public;
+grant execute on function public.match_results(uuid, int) to anon, authenticated;
+
+revoke all on function public.match_users(uuid, int) from public;
+grant execute on function public.match_users(uuid, int) to authenticated;


### PR DESCRIPTION
## PR 본문

### 반영 브랜치

SS-299-RpcVisibilityFilter -> dev

closes #299

### PR 타입

- [x] 기능 추가 (DB 마이그레이션 — RPC 함수 갱신)

### 작업 내용

유사도 검색 RPC(`match_results` / `match_users`)가 `results.is_public = true`만 필터해서, 프로필을 `followers`로 설정한 사용자의 결과가 팔로워가 아닌 호출자에게도 노출되던 갭을 닫습니다. (피드 #289 / 프로필 #279는 이미 visibility 반영 — RPC만 남아 있던 #290 후속)

**정책**: `is_public = true` 이고 작성자 프로필이 호출자에게 열람 가능할 때만 반환
- `public` → 전체 노출
- `followers` → 호출자가 팔로워일 때만 (`auth.uid()` 기준)
- `private` → 제외 (#290 kill-switch로 이미 `is_public=false`가 되지만 방어적으로도 제외)

```sql
and (
  p.visibility = 'public'
  or (
    p.visibility = 'followers'
    and exists (
      select 1 from follows f
      where f.following_id = p.id and f.follower_id = auth.uid()
    )
  )
)
```

- `match_results`: `profiles` join 추가 후 위 조건 적용
- `match_users`: 이미 `profiles` join 존재 → 조건만 추가
- 두 함수 모두 `language sql` / SECURITY INVOKER라 PostgREST RPC 호출 시 `auth.uid()`가 호출자를 가리킵니다. anon 호출(`match_results`)은 `auth.uid()`가 null → followers 분기 false → public만 노출.

### 마이그레이션 번호

`0113`. (0111=#287 RLS 검증, 0112=#301 is_public 기본값 예약)

### 테스트 결과

- SQL 전용 (tsc/lint 대상 없음)
- ⚠️ 로컬 DB 미보유로 **실행 검증은 못 했습니다.** 기존 0109/0110 함수 구조를 그대로 유지하고 WHERE 조건만 추가했습니다. 병합 전 Supabase 프리뷰에서 아래 시나리오 확인 권장:
  - [ ] public 프로필 결과가 유사검색에 노출
  - [ ] followers 프로필 결과가 팔로워에게만 노출, 비팔로워에겐 미노출
  - [ ] anon 호출 시 public만 노출

### 리뷰 요구사항

- `auth.uid()`가 두 함수 컨텍스트에서 호출자를 정확히 반환하는지(특히 anon `match_results`)만 프리뷰에서 확인 부탁드립니다.
- ⚠️ 머지된 RPC(0109/0110)를 `create or replace`로 갱신합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKLhaEPP1Lh7CdfhcFsNY7