### PR TITLE
fix / SS-fix-CompareSuspense - /compare 프로덕션 빌드 실패 수정 (useSearchParams Suspense)

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
@@ -144,7 +144,7 @@ function CompareSide({
   );
 }
 
-export default function ComparePage() {
+function CompareContent() {
   const searchParams = useSearchParams();
   const idA = searchParams.get("a");
   const idB = searchParams.get("b");
@@ -175,5 +175,20 @@ export default function ComparePage() {
         <CompareSide {...sideB} label="결과 B" />
       </div>
     </div>
+  );
+}
+
+// useSearchParams()는 정적 프리렌더 시 Suspense 경계가 필요하다 (Next.js CSR bailout).
+export default function ComparePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="page-container section-wrapper">
+          <p className="type-body-lg text-on-surface-variant">불러오는 중...</p>
+        </div>
+      }
+    >
+      <CompareContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## PR 본문

### 반영 브랜치

SS-fix-CompareSuspense -> dev

closes #304

### PR 타입

- [x] 버그 수정

### 작업 내용

**dev에서 `next build`가 실패하고 있어 긴급 수정합니다.** 16개 PR 머지 후 dev 통합 검증(전체 빌드)을 돌리다 발견했습니다.

`/compare`(#288)가 `useSearchParams()`를 Suspense 경계 없이 사용해, 정적 프리렌더 시 CSR bailout 에러로 빌드가 실패했습니다.

```
⨯ useSearchParams() should be wrapped in a suspense boundary at page "/compare".
> Export encountered errors on following paths: /compare/page: /compare
```

**수정**: 페이지 내용을 `CompareContent`로 분리하고 default export가 `<Suspense>`로 감싸도록 변경.

```tsx
export default function ComparePage() {
  return (
    <Suspense fallback={<div className="page-container section-wrapper">...</div>}>
      <CompareContent />
    </Suspense>
  );
}
```

### 왜 개별 PR CI에서 안 잡혔나

CI(`ci.yml`)가 `type-check` / `lint` / `commit-lint`만 돌리고 **`next build`를 실행하지 않습니다.** 그래서 #288에서 통과하고 머지된 뒤 dev 빌드가 깨졌습니다. → CI에 빌드 단계를 추가하는 후속 이슈를 별도로 제안하겠습니다.

### 테스트 결과

```
$ npx next build
✓ Compiled successfully
✓ Generating static pages (28/28)
├ ○ /compare    2.92 kB   105 kB   ← 정상 프리렌더
```
- `next build` 전체 성공 (수정 전엔 `/compare`에서 실패)
- `tsc --noEmit` / `next lint` 클린
- `useSearchParams` 사용 페이지는 `/compare`가 유일 (다른 페이지 영향 없음 확인)

### 리뷰 요구사항

- dev 빌드가 깨진 상태라 우선 머지 권장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKLhaEPP1Lh7CdfhcFsNY7